### PR TITLE
feat(V8): added a partial functionality of v8::Object, added trait bounds to Local<T>

### DIFF
--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -1,4 +1,4 @@
-use v8::value::traits::Value;
+use v8::{object::traits::Object, value::traits::Value};
 
 fn main() {
     let platform = v8::platform::Platform::new(
@@ -23,8 +23,9 @@ fn main() {
         let source = v8::string::String::new_from_utf8(
             handle_scope,
             r#""hello, " + "world""#,
-            v8::NewStringType::Normal,
+            v8::string::NewStringType::Normal,
         );
+
         let mut script = v8::script::Script::compile(&context, &source);
 
         let result = script.run(&context);
@@ -33,6 +34,40 @@ fn main() {
             "result = {}",
             result.to_string(&context).as_str(handle_scope)
         );
+
+        let mut test = v8::object::Object::new(handle_scope);
+        test.set(
+            &context,
+            &v8::string::String::new_from_utf8(
+                handle_scope,
+                "test",
+                v8::string::NewStringType::Normal,
+            )
+            .cast(),
+            &v8::string::String::new_from_utf8(
+                handle_scope,
+                "test",
+                v8::string::NewStringType::Normal,
+            )
+            .cast(),
+            None,
+        );
+
+        println!(
+            "{{ test: {} }}",
+            test.get(
+                &context,
+                &v8::string::String::new_from_utf8(
+                    handle_scope,
+                    "test",
+                    v8::string::NewStringType::Normal
+                )
+                .cast(),
+                None
+            )
+            .cast::<v8::string::String>()
+            .as_str(handle_scope)
+        )
     }
 
     v8::v8::dispose();

--- a/v8/src/boolean.rs
+++ b/v8/src/boolean.rs
@@ -1,6 +1,6 @@
 use crate::{
     data::traits::Data, isolate::Isolate, local::Local, primitive::traits::Primitive,
-    scope::HandleScope,
+    scope::HandleScope, value::traits::Value,
 };
 
 extern "C" {
@@ -35,4 +35,5 @@ impl Into<bool> for &Boolean {
 }
 
 impl Data for Boolean {}
+impl Value for Boolean {}
 impl Primitive for Boolean {}

--- a/v8/src/cpp/v8.cc
+++ b/v8/src/cpp/v8.cc
@@ -722,3 +722,122 @@ extern "C"
         new (local_buf) v8::Local<v8::Value>(script->Run(*context).ToLocalChecked());
     }
 }
+
+// v8::Name
+extern "C"
+{
+    int v8cxx__name_get_identity_hash(v8::Name *name)
+    {
+        return name->GetIdentityHash();
+    }
+}
+
+// v8::Object
+extern "C"
+{
+    void v8cxx__object_new(v8::Local<v8::Object> *local_buf, v8::Isolate *isolate)
+    {
+        new (local_buf) v8::Local<v8::Object>(v8::Object::New(isolate));
+    }
+    bool v8cxx__object_set(
+        v8::Object *object,
+        const v8::Local<v8::Context> *context,
+        const v8::Local<v8::Value> *key,
+        const v8::Local<v8::Value> *value,
+        const v8::Local<v8::Object> *receiver)
+    {
+        auto result = false;
+
+        if (receiver == nullptr)
+        {
+            object->Set(*context, *key, *value).FromMaybe(&result);
+        }
+        else
+        {
+            object->Set(*context, *key, *value, *receiver).FromMaybe(&result);
+        }
+
+        return result;
+    }
+
+    bool v8cxx__object_set_indexed(
+        v8::Object *object,
+        const v8::Local<v8::Context> *context,
+        uint32_t index,
+        const v8::Local<v8::Value> *value)
+    {
+        auto result = false;
+
+        object->Set(*context, index, *value).FromMaybe(&result);
+
+        return result;
+    }
+
+    bool v8cxx__object_create_data_property(
+        v8::Object *object,
+        const v8::Local<v8::Context> *context,
+        const v8::Local<v8::Name> *key,
+        const v8::Local<v8::Value> *value)
+    {
+        auto result = false;
+
+        object->CreateDataProperty(*context, *key, *value).FromMaybe(&result);
+
+        return result;
+    }
+
+    bool v8cxx__object_create_data_property_indexed(
+        v8::Object *object,
+        const v8::Local<v8::Context> *context,
+        uint32_t index,
+        const v8::Local<v8::Value> *value)
+    {
+        auto result = false;
+
+        object->CreateDataProperty(*context, index, *value).FromMaybe(&result);
+
+        return result;
+    }
+
+    bool v8cxx__object_define_own_property(
+        v8::Object *object,
+        const v8::Local<v8::Context> *context,
+        const v8::Local<v8::Name> *key,
+        const v8::Local<v8::Value> *value,
+        v8::PropertyAttribute attributes)
+    {
+        auto result = false;
+
+        object->DefineOwnProperty(*context, *key, *value, attributes).FromMaybe(&result);
+
+        return result;
+    }
+
+    // TODO: v8cxx__object_define_property
+
+    void v8cxx__object_get(
+        v8::Local<v8::Value> *local_buf,
+        v8::Object *object,
+        const v8::Local<v8::Context> *context,
+        const v8::Local<v8::Value> *key,
+        const v8::Local<v8::Object> *receiver)
+    {
+        if (receiver == nullptr)
+        {
+            new (local_buf) v8::Local<v8::Value>(object->Get(*context, *key).ToLocalChecked());
+        }
+        else
+        {
+            new (local_buf) v8::Local<v8::Value>(object->Get(*context, *key, *receiver).ToLocalChecked());
+        }
+    }
+
+    void v8cxx__object_get_indexed(
+        v8::Local<v8::Value> *local_buf,
+        v8::Object *object,
+        const v8::Local<v8::Context> *context,
+        uint32_t index)
+    {
+        new (local_buf) v8::Local<v8::Value>(object->Get(*context, index).ToLocalChecked());
+    }
+}

--- a/v8/src/lib.rs
+++ b/v8/src/lib.rs
@@ -13,7 +13,9 @@ pub mod data;
 pub mod isolate;
 pub mod local;
 pub mod microtask_queue;
+pub mod name;
 pub mod number;
+pub mod numeric;
 pub mod object;
 pub mod object_template;
 pub mod platform;
@@ -30,10 +32,4 @@ pub fn get_version() -> String {
         "{}.{}.{}",
         v8cxx__major_version, v8cxx__minor_version, v8cxx__patch_level
     )
-}
-
-#[repr(C)]
-pub enum NewStringType {
-    Normal,
-    Internalized,
 }

--- a/v8/src/local.rs
+++ b/v8/src/local.rs
@@ -3,17 +3,24 @@ use std::{
     ptr::NonNull,
 };
 
-#[repr(C)]
-pub struct Local<T>(NonNull<T>);
+use crate::data::traits::Data;
 
-impl<T> Local<T> {
+#[repr(C)]
+pub struct Local<T: Data>(NonNull<T>);
+
+impl<T: Data> Local<T> {
     #[inline(always)]
     pub fn empty() -> Self {
         Self(NonNull::dangling())
     }
+
+    #[inline(always)]
+    pub fn cast<U: Data>(self) -> Local<U> {
+        Local(self.0.cast())
+    }
 }
 
-impl<T> Deref for Local<T> {
+impl<T: Data> Deref for Local<T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -21,13 +28,13 @@ impl<T> Deref for Local<T> {
     }
 }
 
-impl<T> DerefMut for Local<T> {
+impl<T: Data> DerefMut for Local<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe { self.0.as_mut() }
     }
 }
 
-impl<T> Drop for Local<T> {
+impl<T: Data> Drop for Local<T> {
     fn drop(&mut self) {
         unsafe { self.0.drop_in_place() };
     }

--- a/v8/src/name.rs
+++ b/v8/src/name.rs
@@ -1,0 +1,25 @@
+use crate::{data::traits::Data, primitive::traits::Primitive, value::traits::Value};
+
+extern "C" {
+    fn v8cxx__name_get_identity_hash(this: *mut Name) -> i32;
+}
+
+#[repr(C)]
+pub struct Name([u8; 0]);
+
+impl Data for Name {}
+impl Value for Name {}
+impl Primitive for Name {}
+impl traits::Name for Name {}
+
+pub mod traits {
+    use crate::primitive::traits::Primitive;
+
+    use super::v8cxx__name_get_identity_hash;
+
+    pub trait Name: Primitive {
+        fn get_identity_hash(&mut self) -> i32 {
+            unsafe { v8cxx__name_get_identity_hash(self as *mut _ as *mut _) }
+        }
+    }
+}

--- a/v8/src/number.rs
+++ b/v8/src/number.rs
@@ -1,2 +1,12 @@
+use crate::{
+    data::traits::Data, numeric::traits::Numeric, primitive::traits::Primitive,
+    value::traits::Value,
+};
+
 #[repr(C)]
 pub struct Number([u8; 0]);
+
+impl Data for Number {}
+impl Value for Number {}
+impl Primitive for Number {}
+impl Numeric for Number {}

--- a/v8/src/numeric.rs
+++ b/v8/src/numeric.rs
@@ -1,0 +1,14 @@
+use crate::{data::traits::Data, primitive::traits::Primitive, value::traits::Value};
+
+#[repr(C)]
+pub struct Numeric([u8; 0]);
+
+impl Data for Numeric {}
+impl Value for Numeric {}
+impl Primitive for Numeric {}
+
+pub mod traits {
+    use crate::primitive::traits::Primitive;
+
+    pub trait Numeric: Primitive {}
+}

--- a/v8/src/object.rs
+++ b/v8/src/object.rs
@@ -1,2 +1,193 @@
+use crate::{
+    context::Context,
+    data::traits::Data,
+    isolate::Isolate,
+    local::Local,
+    name::Name,
+    scope::HandleScope,
+    value::{self, Value},
+};
+
+extern "C" {
+    fn v8cxx__object_new(local_buf: *mut Local<Object>, isolate: *mut Isolate);
+    fn v8cxx__object_set(
+        this: *mut Object,
+        context: *const Local<Context>,
+        key: *const Local<value::Value>,
+        value: *const Local<value::Value>,
+        receiver: *const Local<Object>,
+    ) -> bool;
+    fn v8cxx__object_set_indexed(
+        this: *mut Object,
+        context: *const Local<Context>,
+        index: u32,
+        value: *const Local<value::Value>,
+    ) -> bool;
+    fn v8cxx__object_create_data_property(
+        this: *mut Object,
+        context: *const Local<Context>,
+        key: *const Local<Name>,
+        value: *const Local<value::Value>,
+    ) -> bool;
+    fn v8cxx__object_create_data_property_indexed(
+        this: *mut Object,
+        context: *const Local<Context>,
+        index: u32,
+        value: *const Local<value::Value>,
+    ) -> bool;
+    fn v8cxx__object_define_own_property(
+        this: *mut Object,
+        context: *const Local<Context>,
+        key: *const Local<Name>,
+        value: *const Local<Value>,
+        attributes: PropertyAttribute,
+    ) -> bool;
+    fn v8cxx__object_get(
+        local_buf: *mut Local<Value>,
+        this: *mut Object,
+        context: *const Local<Context>,
+        key: *const Local<Value>,
+        receiver: *const Local<Object>,
+    );
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub enum PropertyAttribute {
+    None = 0,
+    ReadOnly = 1 << 0,
+    DontEnum = 1 << 1,
+    DontDelete = 1 << 2,
+}
+
 #[repr(C)]
 pub struct Object([u8; 0]);
+
+impl Object {
+    #[inline(always)]
+    pub fn new(handle_scope: &mut HandleScope) -> Local<Self> {
+        let mut local_object = Local::<Self>::empty();
+
+        unsafe {
+            v8cxx__object_new(&mut local_object, handle_scope.get_isolate().unwrap());
+        }
+
+        local_object
+    }
+}
+
+impl Data for Object {}
+impl value::traits::Value for Object {}
+impl traits::Object for Object {}
+
+pub mod traits {
+    use crate::{
+        context::Context,
+        local::Local,
+        name::Name,
+        value::{self, traits::Value},
+    };
+
+    use super::*;
+
+    pub trait Object: Value {
+        fn set(
+            &mut self,
+            context: &Local<Context>,
+            key: &Local<value::Value>,
+            value: &Local<value::Value>,
+            receiver: Option<&Local<super::Object>>,
+        ) {
+            unsafe {
+                v8cxx__object_set(
+                    self as *mut _ as *mut _,
+                    context,
+                    key,
+                    value,
+                    match receiver {
+                        Some(receiver) => receiver,
+                        None => std::ptr::null::<Local<super::Object>>(),
+                    },
+                )
+            };
+        }
+
+        fn set_indexed(
+            &mut self,
+            context: &Local<Context>,
+            index: u32,
+            value: &Local<value::Value>,
+        ) {
+            unsafe { v8cxx__object_set_indexed(self as *mut _ as *mut _, context, index, value) };
+        }
+
+        fn create_data_property(
+            &mut self,
+            context: &Local<Context>,
+            key: &Local<Name>,
+            value: &Local<value::Value>,
+        ) {
+            unsafe {
+                v8cxx__object_create_data_property(self as *mut _ as *mut _, context, key, value)
+            };
+        }
+
+        fn create_data_property_indexed(
+            &mut self,
+            context: &Local<Context>,
+            index: u32,
+            value: &Local<value::Value>,
+        ) {
+            unsafe {
+                v8cxx__object_create_data_property_indexed(
+                    self as *mut _ as *mut _,
+                    context,
+                    index,
+                    value,
+                )
+            };
+        }
+
+        fn define_own_property(
+            &mut self,
+            context: &Local<Context>,
+            key: &Local<Name>,
+            value: &Local<value::Value>,
+            attributes: PropertyAttribute,
+        ) -> bool {
+            unsafe {
+                v8cxx__object_define_own_property(
+                    self as *mut _ as *mut _,
+                    context,
+                    key,
+                    value,
+                    attributes,
+                )
+            }
+        }
+
+        fn get(
+            &mut self,
+            context: &Local<Context>,
+            key: &Local<value::Value>,
+            receiver: Option<&Local<super::Object>>,
+        ) -> Local<value::Value> {
+            let mut local_value = Local::<value::Value>::empty();
+
+            unsafe {
+                v8cxx__object_get(
+                    &mut local_value,
+                    self as *mut _ as *mut _,
+                    context,
+                    key,
+                    match receiver {
+                        Some(receiver) => receiver,
+                        None => std::ptr::null::<Local<super::Object>>(),
+                    },
+                );
+            }
+
+            local_value
+        }
+    }
+}

--- a/v8/src/primitive.rs
+++ b/v8/src/primitive.rs
@@ -1,4 +1,6 @@
-use crate::{isolate::Isolate, local::Local, scope::HandleScope};
+use crate::{
+    data::traits::Data, isolate::Isolate, local::Local, scope::HandleScope, value::traits::Value,
+};
 
 extern "C" {
     fn v8cxx__primitive_undefined(local_buf: *mut Local<Primitive>, isolate: *mut Isolate);
@@ -30,8 +32,12 @@ impl Primitive {
     }
 }
 
-pub mod traits {
-    use crate::data::traits::Data;
+impl Data for Primitive {}
+impl Value for Primitive {}
+impl traits::Primitive for Primitive {}
 
-    pub trait Primitive: Data {}
+pub mod traits {
+    use crate::value::traits::Value;
+
+    pub trait Primitive: Value {}
 }

--- a/v8/src/script.rs
+++ b/v8/src/script.rs
@@ -1,4 +1,4 @@
-use crate::{context::Context, local::Local, string::String, value::Value};
+use crate::{context::Context, data::traits::Data, local::Local, string::String, value::Value};
 
 extern "C" {
     fn v8cxx__script_compile(
@@ -38,3 +38,5 @@ impl Script {
         local_value
     }
 }
+
+impl Data for Script {}

--- a/v8/src/string.rs
+++ b/v8/src/string.rs
@@ -2,7 +2,7 @@ use core::str;
 
 use crate::{
     data::traits::Data, isolate::Isolate, local::Local, primitive::traits::Primitive,
-    scope::HandleScope, value::traits::Value, NewStringType,
+    scope::HandleScope, value::traits::Value,
 };
 
 extern "C" {
@@ -43,6 +43,13 @@ extern "C" {
         isolate: *mut Isolate,
     );
     fn v8cxx__string_view(this: *const String, isolate: *mut Isolate) -> *const u8;
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub enum NewStringType {
+    Normal,
+    Internalized,
 }
 
 #[repr(C)]

--- a/v8/src/symbol.rs
+++ b/v8/src/symbol.rs
@@ -1,4 +1,7 @@
-use crate::{isolate::Isolate, local::Local, scope::HandleScope, string::String};
+use crate::{
+    data::traits::Data, isolate::Isolate, local::Local, name::traits::Name,
+    primitive::traits::Primitive, scope::HandleScope, string::String, value::traits::Value,
+};
 
 extern "C" {
     fn v8cxx__symbol_new(
@@ -97,10 +100,7 @@ impl Symbol {
         let mut local_symbol = Local::<Self>::empty();
 
         unsafe {
-            v8cxx__symbol_get_has_instance(
-                &mut local_symbol,
-                handle_scope.get_isolate().unwrap(),
-            );
+            v8cxx__symbol_get_has_instance(&mut local_symbol, handle_scope.get_isolate().unwrap());
         }
 
         local_symbol
@@ -125,10 +125,7 @@ impl Symbol {
         let mut local_symbol = Local::<Self>::empty();
 
         unsafe {
-            v8cxx__symbol_get_iterator(
-                &mut local_symbol,
-                handle_scope.get_isolate().unwrap(),
-            );
+            v8cxx__symbol_get_iterator(&mut local_symbol, handle_scope.get_isolate().unwrap());
         }
 
         local_symbol
@@ -139,10 +136,7 @@ impl Symbol {
         let mut local_symbol = Local::<Self>::empty();
 
         unsafe {
-            v8cxx__symbol_get_match(
-                &mut local_symbol,
-                handle_scope.get_isolate().unwrap(),
-            );
+            v8cxx__symbol_get_match(&mut local_symbol, handle_scope.get_isolate().unwrap());
         }
 
         local_symbol
@@ -153,10 +147,7 @@ impl Symbol {
         let mut local_symbol = Local::<Self>::empty();
 
         unsafe {
-            v8cxx__symbol_get_replace(
-                &mut local_symbol,
-                handle_scope.get_isolate().unwrap(),
-            );
+            v8cxx__symbol_get_replace(&mut local_symbol, handle_scope.get_isolate().unwrap());
         }
 
         local_symbol
@@ -167,10 +158,7 @@ impl Symbol {
         let mut local_symbol = Local::<Self>::empty();
 
         unsafe {
-            v8cxx__symbol_get_search(
-                &mut local_symbol,
-                handle_scope.get_isolate().unwrap(),
-            );
+            v8cxx__symbol_get_search(&mut local_symbol, handle_scope.get_isolate().unwrap());
         }
 
         local_symbol
@@ -181,10 +169,7 @@ impl Symbol {
         let mut local_symbol = Local::<Self>::empty();
 
         unsafe {
-            v8cxx__symbol_get_split(
-                &mut local_symbol,
-                handle_scope.get_isolate().unwrap(),
-            );
+            v8cxx__symbol_get_split(&mut local_symbol, handle_scope.get_isolate().unwrap());
         }
 
         local_symbol
@@ -195,10 +180,7 @@ impl Symbol {
         let mut local_symbol = Local::<Self>::empty();
 
         unsafe {
-            v8cxx__symbol_get_to_primitive(
-                &mut local_symbol,
-                handle_scope.get_isolate().unwrap(),
-            );
+            v8cxx__symbol_get_to_primitive(&mut local_symbol, handle_scope.get_isolate().unwrap());
         }
 
         local_symbol
@@ -209,10 +191,7 @@ impl Symbol {
         let mut local_symbol = Local::<Self>::empty();
 
         unsafe {
-            v8cxx__symbol_get_to_string_tag(
-                &mut local_symbol,
-                handle_scope.get_isolate().unwrap(),
-            );
+            v8cxx__symbol_get_to_string_tag(&mut local_symbol, handle_scope.get_isolate().unwrap());
         }
 
         local_symbol
@@ -223,12 +202,14 @@ impl Symbol {
         let mut local_symbol = Local::<Self>::empty();
 
         unsafe {
-            v8cxx__symbol_get_unscopables(
-                &mut local_symbol,
-                handle_scope.get_isolate().unwrap(),
-            );
+            v8cxx__symbol_get_unscopables(&mut local_symbol, handle_scope.get_isolate().unwrap());
         }
 
         local_symbol
     }
 }
+
+impl Data for Symbol {}
+impl Value for Symbol {}
+impl Primitive for Symbol {}
+impl Name for Symbol {}


### PR DESCRIPTION
In this PR were implemented the following things:
- added v8::Object and its several methods
- added needed traits for already implemented v8 structs
- added trait bounds for Local<T>. Now T requires Data trait
- added v8::Name and trait Name
- added v8::Numeric and trait Numeric