### PR TITLE
refactor: improved usage for derived from v8::Value structs

### DIFF
--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -20,11 +20,7 @@ fn main() {
         let handle_scope = v8::scope::HandleScope::new(isolate).unwrap();
         let context = v8::context::Context::new(handle_scope);
 
-        let source = v8::string::String::new_from_utf8(
-            handle_scope,
-            r#""hello, " + "world""#,
-            v8::string::NewStringType::Normal,
-        );
+        let source = v8::string::String::new(handle_scope, r#""hello, " + "world""#);
 
         let mut script = v8::script::Script::compile(&context, &source);
 
@@ -36,20 +32,11 @@ fn main() {
         );
 
         let mut test = v8::object::Object::new(handle_scope);
+
         test.set(
             &context,
-            &v8::string::String::new_from_utf8(
-                handle_scope,
-                "test",
-                v8::string::NewStringType::Normal,
-            )
-            .cast(),
-            &v8::string::String::new_from_utf8(
-                handle_scope,
-                "test",
-                v8::string::NewStringType::Normal,
-            )
-            .cast(),
+            &v8::string::String::new(handle_scope, "test"),
+            &v8::string::String::new(handle_scope, "test"),
             None,
         );
 
@@ -57,12 +44,7 @@ fn main() {
             "{{ test: {} }}",
             test.get(
                 &context,
-                &v8::string::String::new_from_utf8(
-                    handle_scope,
-                    "test",
-                    v8::string::NewStringType::Normal
-                )
-                .cast(),
+                &v8::string::String::new(handle_scope, "test"),
                 None
             )
             .cast::<v8::string::String>()

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -17,38 +17,39 @@ fn main() {
             v8::array_buffer::ArrayBufferAllocator::new().unwrap(),
         );
         let isolate = v8::isolate::Isolate::new(isolate_create_params).unwrap();
-        let handle_scope = v8::scope::HandleScope::new(isolate).unwrap();
-        let context = v8::context::Context::new(handle_scope);
+        let handle_scope = v8::scope::HandleScope::new(isolate);
+        let context = v8::context::Context::new(&handle_scope);
+        let context_scope = v8::scope::ContextScope::new(context);
 
-        let source = v8::string::String::new(handle_scope, r#""hello, " + "world""#);
+        let source = v8::string::String::new(&handle_scope, r#""hello, " + "world""#);
 
-        let mut script = v8::script::Script::compile(&context, &source);
+        let mut script = v8::script::Script::compile(&context_scope, &source);
 
-        let result = script.run(&context);
+        let result = script.run(&context_scope);
 
         println!(
             "result = {}",
-            result.to_string(&context).as_str(handle_scope)
+            result.to_string(&context_scope).as_str(&handle_scope)
         );
 
-        let mut test = v8::object::Object::new(handle_scope);
+        let mut test = v8::object::Object::new(&handle_scope);
 
         test.set(
-            &context,
-            &v8::string::String::new(handle_scope, "test"),
-            &v8::string::String::new(handle_scope, "test"),
+            &context_scope,
+            &v8::string::String::new(&handle_scope, "test"),
+            &v8::string::String::new(&handle_scope, "test"),
             None,
         );
 
         println!(
             "{{ test: {} }}",
             test.get(
-                &context,
-                &v8::string::String::new(handle_scope, "test"),
+                &context_scope,
+                &v8::string::String::new(&handle_scope, "test"),
                 None
             )
             .cast::<v8::string::String>()
-            .as_str(handle_scope)
+            .as_str(&handle_scope)
         )
     }
 

--- a/v8/src/bigint.rs
+++ b/v8/src/bigint.rs
@@ -12,7 +12,7 @@ pub struct BigInt([u8; 0]);
 
 impl BigInt {
     #[inline(always)]
-    pub fn new(handle_scope: &mut HandleScope, value: i64) -> Local<Self> {
+    pub fn new(handle_scope: &HandleScope, value: i64) -> Local<Self> {
         let mut local_bigint = Local::<Self>::empty();
 
         unsafe {

--- a/v8/src/boolean.rs
+++ b/v8/src/boolean.rs
@@ -13,7 +13,7 @@ pub struct Boolean([u8; 0]);
 
 impl Boolean {
     #[inline(always)]
-    pub fn new(handle_scope: &mut HandleScope, value: bool) -> Local<Self> {
+    pub fn new(handle_scope: &HandleScope, value: bool) -> Local<Self> {
         let mut local_boolean = Local::<Self>::empty();
 
         unsafe {

--- a/v8/src/context.rs
+++ b/v8/src/context.rs
@@ -19,17 +19,16 @@ impl Context {
             v8cxx__context_new(&mut local_context, handle_scope.get_isolate().unwrap());
         }
 
-        local_context.enter();
         local_context
     }
 
     #[inline(always)]
-    fn enter(&mut self) {
+    pub(super) fn enter(&mut self) {
         unsafe { v8cxx__context_enter(self) };
     }
 
     #[inline(always)]
-    fn exit(&mut self) {
+    pub(super) fn exit(&mut self) {
         unsafe { v8cxx__context_exit(self) };
     }
 
@@ -40,9 +39,3 @@ impl Context {
 }
 
 impl Data for Context {}
-
-impl Drop for Context {
-    fn drop(&mut self) {
-        self.exit();
-    }
-}

--- a/v8/src/context.rs
+++ b/v8/src/context.rs
@@ -12,7 +12,7 @@ pub struct Context([u8; 0]);
 
 impl Context {
     #[inline(always)]
-    pub fn new(handle_scope: &mut HandleScope) -> Local<Self> {
+    pub fn new(handle_scope: &HandleScope) -> Local<Self> {
         let mut local_context = Local::<Self>::empty();
 
         unsafe {

--- a/v8/src/cpp/v8.cc
+++ b/v8/src/cpp/v8.cc
@@ -114,14 +114,14 @@ extern "C"
         v8::HandleScope handle_scope;
     };
 
-    HandleScope *v8cxx__handlescope_new(v8::Isolate *isolate)
+    void v8cxx__handlescope_new(HandleScope *buf, v8::Isolate *isolate)
     {
-        return new HandleScope(isolate);
+        new (buf) HandleScope(isolate);
     }
 
     void v8cxx__handlescope_drop(HandleScope *handle_scope)
     {
-        delete handle_scope;
+        handle_scope->~HandleScope();
     }
 
     v8::Isolate *v8cxx__handlescope_get_isolate(const HandleScope *handle_scope)

--- a/v8/src/cpp/v8.cc
+++ b/v8/src/cpp/v8.cc
@@ -75,9 +75,9 @@ extern "C"
         return v8::Isolate::New(create_params);
     }
 
-    v8::Isolate *v8cxx__isolate_get_current(v8::Isolate *isolate)
+    v8::Isolate *v8cxx__isolate_get_current()
     {
-        return isolate->GetCurrent();
+        return v8::Isolate::GetCurrent();
     }
 
     void v8cxx__isolate_get_current_context(v8::Local<v8::Context> *local_buf, v8::Isolate *isolate)
@@ -105,7 +105,7 @@ extern "C"
         HandleScope(v8::Isolate *isolate) : handle_scope(isolate) {}
         ~HandleScope() {}
 
-        v8::HandleScope &get()
+        const v8::HandleScope &get() const
         {
             return this->handle_scope;
         }
@@ -124,7 +124,7 @@ extern "C"
         delete handle_scope;
     }
 
-    v8::Isolate *v8cxx__handlescope_get_isolate(HandleScope *handle_scope)
+    v8::Isolate *v8cxx__handlescope_get_isolate(const HandleScope *handle_scope)
     {
         return handle_scope->get().GetIsolate();
     }

--- a/v8/src/data.rs
+++ b/v8/src/data.rs
@@ -18,7 +18,7 @@ pub mod traits {
         v8cxx__data_is_value,
     };
 
-    pub trait Data {
+    pub trait Data: Sized {
         fn is_context(&self) -> bool {
             unsafe { v8cxx__data_is_context(self as *const _ as *const _) }
         }

--- a/v8/src/isolate.rs
+++ b/v8/src/isolate.rs
@@ -8,7 +8,7 @@ extern "C" {
     fn v8cxx__isolate_new(create_params: *const IsolateCreateParams) -> *mut Isolate;
     fn v8cxx__isolate_enter(this: *mut Isolate);
     fn v8cxx__isolate_exit(this: *mut Isolate);
-    fn v8cxx__isolate_get_current(this: *mut Isolate) -> *mut Isolate;
+    fn v8cxx__isolate_get_current() -> *mut Isolate;
     fn v8cxx__isolate_get_current_context(local_buf: *mut Local<Context>, this: *mut Isolate);
 }
 
@@ -47,8 +47,8 @@ impl Isolate {
     }
 
     #[inline(always)]
-    pub fn get_current(&mut self) -> Option<&mut Self> {
-        unsafe { v8cxx__isolate_get_current(self).as_mut() }
+    pub fn get_current<'a>() -> Option<&'a mut Self> {
+        unsafe { v8cxx__isolate_get_current().as_mut() }
     }
 
     #[inline(always)]

--- a/v8/src/local.rs
+++ b/v8/src/local.rs
@@ -1,4 +1,5 @@
 use std::{
+    mem::transmute,
     ops::{Deref, DerefMut},
     ptr::NonNull,
 };
@@ -17,6 +18,16 @@ impl<T: Data> Local<T> {
     #[inline(always)]
     pub fn cast<U: Data>(self) -> Local<U> {
         Local(self.0.cast())
+    }
+
+    #[inline(always)]
+    pub fn cast_ref<U: Data>(&self) -> &Local<U> {
+        unsafe { transmute(self) }
+    }
+
+    #[inline(always)]
+    pub fn cast_mut<U: Data>(&mut self) -> &mut Local<U> {
+        unsafe { transmute(self) }
     }
 }
 

--- a/v8/src/object.rs
+++ b/v8/src/object.rs
@@ -65,7 +65,7 @@ pub struct Object([u8; 0]);
 
 impl Object {
     #[inline(always)]
-    pub fn new(handle_scope: &mut HandleScope) -> Local<Self> {
+    pub fn new(handle_scope: &HandleScope) -> Local<Self> {
         let mut local_object = Local::<Self>::empty();
 
         unsafe {
@@ -81,12 +81,7 @@ impl value::traits::Value for Object {}
 impl traits::Object for Object {}
 
 pub mod traits {
-    use crate::{
-        context::Context,
-        local::Local,
-        name::Name,
-        value::{self, traits::Value},
-    };
+    use crate::{local::Local, name::traits::Name, value::traits::Value};
 
     use super::*;
 
@@ -94,16 +89,16 @@ pub mod traits {
         fn set(
             &mut self,
             context: &Local<Context>,
-            key: &Local<value::Value>,
-            value: &Local<value::Value>,
+            key: &Local<impl Value>,
+            value: &Local<impl Value>,
             receiver: Option<&Local<super::Object>>,
         ) {
             unsafe {
                 v8cxx__object_set(
                     self as *mut _ as *mut _,
                     context,
-                    key,
-                    value,
+                    key.cast_ref(),
+                    value.cast_ref(),
                     match receiver {
                         Some(receiver) => receiver,
                         None => std::ptr::null::<Local<super::Object>>(),
@@ -112,23 +107,30 @@ pub mod traits {
             };
         }
 
-        fn set_indexed(
-            &mut self,
-            context: &Local<Context>,
-            index: u32,
-            value: &Local<value::Value>,
-        ) {
-            unsafe { v8cxx__object_set_indexed(self as *mut _ as *mut _, context, index, value) };
+        fn set_indexed(&mut self, context: &Local<Context>, index: u32, value: &Local<impl Value>) {
+            unsafe {
+                v8cxx__object_set_indexed(
+                    self as *mut _ as *mut _,
+                    context,
+                    index,
+                    value.cast_ref(),
+                )
+            };
         }
 
         fn create_data_property(
             &mut self,
             context: &Local<Context>,
-            key: &Local<Name>,
-            value: &Local<value::Value>,
+            key: &Local<impl Name>,
+            value: &Local<impl Value>,
         ) {
             unsafe {
-                v8cxx__object_create_data_property(self as *mut _ as *mut _, context, key, value)
+                v8cxx__object_create_data_property(
+                    self as *mut _ as *mut _,
+                    context,
+                    key.cast_ref(),
+                    value.cast_ref(),
+                )
             };
         }
 
@@ -136,14 +138,14 @@ pub mod traits {
             &mut self,
             context: &Local<Context>,
             index: u32,
-            value: &Local<value::Value>,
+            value: &Local<impl Value>,
         ) {
             unsafe {
                 v8cxx__object_create_data_property_indexed(
                     self as *mut _ as *mut _,
                     context,
                     index,
-                    value,
+                    value.cast_ref(),
                 )
             };
         }
@@ -151,16 +153,16 @@ pub mod traits {
         fn define_own_property(
             &mut self,
             context: &Local<Context>,
-            key: &Local<Name>,
-            value: &Local<value::Value>,
+            key: &Local<impl Name>,
+            value: &Local<impl Value>,
             attributes: PropertyAttribute,
         ) -> bool {
             unsafe {
                 v8cxx__object_define_own_property(
                     self as *mut _ as *mut _,
                     context,
-                    key,
-                    value,
+                    key.cast_ref(),
+                    value.cast_ref(),
                     attributes,
                 )
             }
@@ -169,7 +171,7 @@ pub mod traits {
         fn get(
             &mut self,
             context: &Local<Context>,
-            key: &Local<value::Value>,
+            key: &Local<impl Value>,
             receiver: Option<&Local<super::Object>>,
         ) -> Local<value::Value> {
             let mut local_value = Local::<value::Value>::empty();
@@ -179,7 +181,7 @@ pub mod traits {
                     &mut local_value,
                     self as *mut _ as *mut _,
                     context,
-                    key,
+                    key.cast_ref(),
                     match receiver {
                         Some(receiver) => receiver,
                         None => std::ptr::null::<Local<super::Object>>(),

--- a/v8/src/primitive.rs
+++ b/v8/src/primitive.rs
@@ -12,7 +12,7 @@ pub struct Primitive([u8; 0]);
 
 impl Primitive {
     #[inline(always)]
-    pub fn undefined(handle_scope: &mut HandleScope) -> Local<Self> {
+    pub fn undefined(handle_scope: &HandleScope) -> Local<Self> {
         let mut local_primitive = Local::<Self>::empty();
 
         unsafe {
@@ -23,7 +23,7 @@ impl Primitive {
     }
 
     #[inline(always)]
-    pub fn null(handle_scope: &mut HandleScope) -> Local<Self> {
+    pub fn null(handle_scope: &HandleScope) -> Local<Self> {
         let mut local_primitive = Local::<Self>::empty();
 
         unsafe { v8cxx__primitive_null(&mut local_primitive, handle_scope.get_isolate().unwrap()) };

--- a/v8/src/scope.rs
+++ b/v8/src/scope.rs
@@ -3,7 +3,7 @@ use crate::{bindings, isolate::Isolate};
 extern "C" {
     fn v8cxx__handlescope_new(isolate: *mut Isolate) -> *mut HandleScope;
     fn v8cxx__handlescope_drop(this: *mut HandleScope);
-    fn v8cxx__handlescope_get_isolate(this: *mut HandleScope) -> *mut Isolate;
+    fn v8cxx__handlescope_get_isolate(this: *const HandleScope) -> *mut Isolate;
 }
 
 #[repr(C)]
@@ -16,7 +16,7 @@ impl HandleScope {
     }
 
     #[inline(always)]
-    pub fn get_isolate(&mut self) -> Option<&mut Isolate> {
+    pub fn get_isolate(&self) -> Option<&mut Isolate> {
         unsafe { v8cxx__handlescope_get_isolate(self).as_mut() }
     }
 }

--- a/v8/src/string.rs
+++ b/v8/src/string.rs
@@ -57,8 +57,13 @@ pub struct String([u8; 0]);
 
 impl String {
     #[inline(always)]
+    pub fn new(handle_scope: &HandleScope, value: &str) -> Local<Self> {
+        Self::new_from_utf8(handle_scope, value, NewStringType::Normal)
+    }
+
+    #[inline(always)]
     pub fn new_from_utf8(
-        handle_scope: &mut HandleScope,
+        handle_scope: &HandleScope,
         value: &str,
         string_type: NewStringType,
     ) -> Local<Self> {
@@ -79,7 +84,7 @@ impl String {
 
     #[inline(always)]
     pub fn new_from_onebyte(
-        handle_scope: &mut HandleScope,
+        handle_scope: &HandleScope,
         value: &[u8],
         string_type: NewStringType,
     ) -> Local<Self> {
@@ -100,7 +105,7 @@ impl String {
 
     #[inline(always)]
     pub fn new_from_twobyte(
-        handle_scope: &mut HandleScope,
+        handle_scope: &HandleScope,
         value: &[u16],
         string_type: NewStringType,
     ) -> Local<Self> {
@@ -166,7 +171,7 @@ impl String {
     }
 
     #[inline(always)]
-    pub fn as_str(&self, handle_scope: &mut HandleScope) -> &str {
+    pub fn as_str(&self, handle_scope: &HandleScope) -> &str {
         unsafe {
             let length = self.length() as usize;
             let str_buffer = v8cxx__string_view(self, handle_scope.get_isolate().unwrap());

--- a/v8/src/symbol.rs
+++ b/v8/src/symbol.rs
@@ -38,7 +38,7 @@ pub struct Symbol([u8; 0]);
 
 impl Symbol {
     #[inline(always)]
-    pub fn new(handle_scope: &mut HandleScope, name: &Local<String>) -> Local<Self> {
+    pub fn new(handle_scope: &HandleScope, name: &Local<String>) -> Local<Self> {
         let mut local_symbol = Local::<Self>::empty();
 
         unsafe {
@@ -49,7 +49,7 @@ impl Symbol {
     }
 
     #[inline(always)]
-    pub fn for_symbol(handle_scope: &mut HandleScope, description: &Local<String>) -> Local<Self> {
+    pub fn for_symbol(handle_scope: &HandleScope, description: &Local<String>) -> Local<Self> {
         let mut local_symbol = Local::<Self>::empty();
 
         unsafe {
@@ -65,7 +65,7 @@ impl Symbol {
 
     #[inline(always)]
     pub fn for_api_symbol(
-        handle_scope: &mut HandleScope,
+        handle_scope: &HandleScope,
         description: &Local<String>,
     ) -> Local<Self> {
         let mut local_symbol = Local::<Self>::empty();
@@ -82,7 +82,7 @@ impl Symbol {
     }
 
     #[inline(always)]
-    pub fn get_async_iterator(handle_scope: &mut HandleScope) -> Local<Self> {
+    pub fn get_async_iterator(handle_scope: &HandleScope) -> Local<Self> {
         let mut local_symbol = Local::<Self>::empty();
 
         unsafe {
@@ -96,7 +96,7 @@ impl Symbol {
     }
 
     #[inline(always)]
-    pub fn get_has_instance(handle_scope: &mut HandleScope) -> Local<Self> {
+    pub fn get_has_instance(handle_scope: &HandleScope) -> Local<Self> {
         let mut local_symbol = Local::<Self>::empty();
 
         unsafe {
@@ -107,7 +107,7 @@ impl Symbol {
     }
 
     #[inline(always)]
-    pub fn get_is_concat_spreadable(handle_scope: &mut HandleScope) -> Local<Self> {
+    pub fn get_is_concat_spreadable(handle_scope: &HandleScope) -> Local<Self> {
         let mut local_symbol = Local::<Self>::empty();
 
         unsafe {
@@ -121,7 +121,7 @@ impl Symbol {
     }
 
     #[inline(always)]
-    pub fn get_iterator(handle_scope: &mut HandleScope) -> Local<Self> {
+    pub fn get_iterator(handle_scope: &HandleScope) -> Local<Self> {
         let mut local_symbol = Local::<Self>::empty();
 
         unsafe {
@@ -132,7 +132,7 @@ impl Symbol {
     }
 
     #[inline(always)]
-    pub fn get_match(handle_scope: &mut HandleScope) -> Local<Self> {
+    pub fn get_match(handle_scope: &HandleScope) -> Local<Self> {
         let mut local_symbol = Local::<Self>::empty();
 
         unsafe {
@@ -143,7 +143,7 @@ impl Symbol {
     }
 
     #[inline(always)]
-    pub fn get_replace(handle_scope: &mut HandleScope) -> Local<Self> {
+    pub fn get_replace(handle_scope: &HandleScope) -> Local<Self> {
         let mut local_symbol = Local::<Self>::empty();
 
         unsafe {
@@ -154,7 +154,7 @@ impl Symbol {
     }
 
     #[inline(always)]
-    pub fn get_search(handle_scope: &mut HandleScope) -> Local<Self> {
+    pub fn get_search(handle_scope: &HandleScope) -> Local<Self> {
         let mut local_symbol = Local::<Self>::empty();
 
         unsafe {
@@ -165,7 +165,7 @@ impl Symbol {
     }
 
     #[inline(always)]
-    pub fn get_split(handle_scope: &mut HandleScope) -> Local<Self> {
+    pub fn get_split(handle_scope: &HandleScope) -> Local<Self> {
         let mut local_symbol = Local::<Self>::empty();
 
         unsafe {
@@ -176,7 +176,7 @@ impl Symbol {
     }
 
     #[inline(always)]
-    pub fn get_to_primitive(handle_scope: &mut HandleScope) -> Local<Self> {
+    pub fn get_to_primitive(handle_scope: &HandleScope) -> Local<Self> {
         let mut local_symbol = Local::<Self>::empty();
 
         unsafe {
@@ -187,7 +187,7 @@ impl Symbol {
     }
 
     #[inline(always)]
-    pub fn get_to_string_tag(handle_scope: &mut HandleScope) -> Local<Self> {
+    pub fn get_to_string_tag(handle_scope: &HandleScope) -> Local<Self> {
         let mut local_symbol = Local::<Self>::empty();
 
         unsafe {
@@ -198,7 +198,7 @@ impl Symbol {
     }
 
     #[inline(always)]
-    pub fn get_unscopables(handle_scope: &mut HandleScope) -> Local<Self> {
+    pub fn get_unscopables(handle_scope: &HandleScope) -> Local<Self> {
         let mut local_symbol = Local::<Self>::empty();
 
         unsafe {


### PR DESCRIPTION
In this PR were added and/or changed:
- retrieving `v8::Isolate` from immutable `v8::HandleScope`
- passing derived from `T` v8::* structs to argument of functions, where the bound of `T` is `Data`, `Value`, `Primitive` etc.
- cast `Local<T>` to `Local<U>`
- added `v8::scope::ContextScope` struct
- now `v8::scope::HandleScope` is stack-allocated