### PR TITLE
feat(V8): added global, detach_global, get/set_microtask_queue for v8::context::Context, and extended new method

### DIFF
--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -18,7 +18,7 @@ fn main() {
         );
         let isolate = v8::isolate::Isolate::new(isolate_create_params).unwrap();
         let handle_scope = v8::scope::HandleScope::new(isolate);
-        let context = v8::context::Context::new(&handle_scope);
+        let context = v8::context::Context::new(&handle_scope, None);
         let context_scope = v8::scope::ContextScope::new(context);
 
         let source = v8::string::String::new(&handle_scope, r#""hello, " + "world""#);

--- a/v8/src/context.rs
+++ b/v8/src/context.rs
@@ -1,10 +1,41 @@
-use crate::{data::traits::Data, isolate::Isolate, local::Local, scope::HandleScope};
+use crate::{
+    data::traits::Data, isolate::Isolate, local::Local, microtask_queue::MicrotaskQueue,
+    object::Object, object_template::ObjectTemplate, scope::HandleScope, value::Value,
+};
 
 extern "C" {
-    fn v8cxx__context_new(local_buf: *mut Local<Context>, isolate: *mut Isolate);
+    fn v8cxx__context_new(
+        local_buf: *mut Local<Context>,
+        isolate: *mut Isolate,
+        global_template: *const Local<ObjectTemplate>,
+        global_object: *const Local<Value>,
+        microtask_queue: *mut MicrotaskQueue,
+    );
     fn v8cxx__context_enter(this: *mut Context);
     fn v8cxx__context_exit(this: *mut Context);
+    fn v8cxx__context_global(local_buf: *mut Local<Object>, this: *mut Context);
+    fn v8cxx__context_detach_global(this: *mut Context);
     fn v8cxx__context_get_isolate(this: *mut Context) -> *mut Isolate;
+    fn v8cxx__context_get_microtask_queue(this: *mut Context) -> *mut MicrotaskQueue;
+    fn v8cxx__context_set_microtask_queue(this: *mut Context, microtask_queue: *mut MicrotaskQueue);
+}
+
+// TODO: implement MicrotaskQueue
+#[allow(dead_code)]
+pub struct ContextOptions {
+    global_template: Local<ObjectTemplate>,
+    global_object: Local<Value>,
+    microtask_queue: Option<MicrotaskQueue>,
+}
+
+impl ContextOptions {
+    pub fn new(global_template: Local<ObjectTemplate>, global_object: Local<Value>) -> Self {
+        Self {
+            global_template,
+            global_object,
+            microtask_queue: None,
+        }
+    }
 }
 
 #[repr(C)]
@@ -12,11 +43,24 @@ pub struct Context([u8; 0]);
 
 impl Context {
     #[inline(always)]
-    pub fn new(handle_scope: &HandleScope) -> Local<Self> {
+    pub fn new(handle_scope: &HandleScope, options: Option<ContextOptions>) -> Local<Self> {
         let mut local_context = Local::<Self>::empty();
 
         unsafe {
-            v8cxx__context_new(&mut local_context, handle_scope.get_isolate().unwrap());
+            v8cxx__context_new(
+                &mut local_context,
+                handle_scope.get_isolate().unwrap(),
+                match &options {
+                    Some(options) => &options.global_template,
+                    None => std::ptr::null::<Local<ObjectTemplate>>(),
+                },
+                match &options {
+                    Some(options) => &options.global_object,
+                    None => std::ptr::null::<Local<Value>>(),
+                },
+                // TODO: MicrotaskQueue
+                std::ptr::null_mut(),
+            );
         }
 
         local_context
@@ -33,8 +77,34 @@ impl Context {
     }
 
     #[inline(always)]
+    pub fn global(&mut self) -> Local<Object> {
+        let mut local_object = Local::<Object>::empty();
+
+        unsafe {
+            v8cxx__context_global(&mut local_object, self);
+        }
+
+        local_object
+    }
+
+    #[inline(always)]
+    pub fn detach_global(&mut self) {
+        unsafe { v8cxx__context_detach_global(self) };
+    }
+
+    #[inline(always)]
     pub fn get_isolate(&mut self) -> Option<&mut Isolate> {
         unsafe { v8cxx__context_get_isolate(self).as_mut() }
+    }
+
+    #[inline(always)]
+    pub fn get_microtask_queue(&mut self) -> Option<&mut MicrotaskQueue> {
+        unsafe { v8cxx__context_get_microtask_queue(self).as_mut() }
+    }
+
+    #[inline(always)]
+    pub fn set_microtask_queue(&mut self, microtask_queue: &mut MicrotaskQueue) {
+        unsafe { v8cxx__context_set_microtask_queue(self, microtask_queue) };
     }
 }
 

--- a/v8/src/cpp/v8.cc
+++ b/v8/src/cpp/v8.cc
@@ -133,10 +133,20 @@ extern "C"
 // v8::Context
 extern "C"
 {
-    void v8cxx__context_new(v8::Local<v8::Context> *local_buf, v8::Isolate *isolate)
+    void v8cxx__context_new(
+        v8::Local<v8::Context> *local_buf,
+        v8::Isolate *isolate,
+        const v8::Local<v8::ObjectTemplate> *global_template,
+        const v8::Local<v8::Value> *global_object,
+        v8::MicrotaskQueue *microtask_queue)
     {
-        // TODO: new (local_buf) v8::Local<v8::Context(v8::Context::New(isolate, nullptr, global_template, global_object, v8::DeserializeInternalFieldsCallback(), microtask_queue));
-        new (local_buf) v8::Local<v8::Context>(v8::Context::New(isolate));
+        new (local_buf) v8::Local<v8::Context>(v8::Context::New(
+            isolate,
+            nullptr,
+            global_template == nullptr ? v8::MaybeLocal<v8::ObjectTemplate>() : *global_template,
+            global_object == nullptr ? v8::MaybeLocal<v8::Value>() : *global_object,
+            v8::DeserializeInternalFieldsCallback(),
+            microtask_queue));
     }
 
     void v8cxx__context_enter(v8::Context *context)
@@ -149,9 +159,29 @@ extern "C"
         context->Exit();
     }
 
+    void v8cxx__context_global(v8::Local<v8::Object> *local_buf, v8::Context *context)
+    {
+        new (local_buf) v8::Local<v8::Object>(context->Global());
+    }
+
+    void v8cxx__context_detach_global(v8::Context *context)
+    {
+        context->DetachGlobal();
+    }
+
     v8::Isolate *v8cxx__context_get_isolate(v8::Context *context)
     {
         return context->GetIsolate();
+    }
+
+    v8::MicrotaskQueue *v8cxx__context_get_microtask_queue(v8::Context *context)
+    {
+        return context->GetMicrotaskQueue();
+    }
+
+    void v8cxx__context_set_microtask_queue(v8::Context *context, v8::MicrotaskQueue *microtask_queue)
+    {
+        context->SetMicrotaskQueue(microtask_queue);
     }
 }
 

--- a/v8/src/object_template.rs
+++ b/v8/src/object_template.rs
@@ -1,2 +1,6 @@
+use crate::data::traits::Data;
+
 #[repr(C)]
 pub struct ObjectTemplate([u8; 0]);
+
+impl Data for ObjectTemplate {}


### PR DESCRIPTION
In this PR were added:
- `Context::global`
- `Context::detach_global`
- `Context::get_microtask_queue` and `Context::set_microtask_queue`
- Extended `Context::new` method, now it also accepts `ContextOptions` with global template, global object, and microtask queue