### PR TITLE
Improvements

### DIFF
--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -49,8 +49,9 @@ fn main() {
                 None
             )
             .cast::<v8::string::String>()
+            .to_local_checked()
             .as_str(&handle_scope)
-        )
+        );
     }
 
     v8::v8::dispose();

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -29,7 +29,10 @@ fn main() {
 
         println!(
             "result = {}",
-            result.to_string(&context_scope).as_str(&handle_scope)
+            result
+                .to_string(&context_scope)
+                .to_local_checked()
+                .as_str(&handle_scope)
         );
 
         let mut test = v8::object::Object::new(&handle_scope);

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -21,11 +21,12 @@ fn main() {
         let context = v8::context::Context::new(&handle_scope, None);
         let context_scope = v8::scope::ContextScope::new(context);
 
-        let source = v8::string::String::new(&handle_scope, r#""hello, " + "world""#).to_local_checked();
+        let source =
+            v8::string::String::new(&handle_scope, r#""hello, " + "world""#).to_local_checked();
 
-        let mut script = v8::script::Script::compile(&context_scope, &source);
+        let mut script = v8::script::Script::compile(&context_scope, &source).to_local_checked();
 
-        let result = script.run(&context_scope);
+        let result = script.run(&context_scope).to_local_checked();
 
         println!(
             "result = {}",

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -21,7 +21,7 @@ fn main() {
         let context = v8::context::Context::new(&handle_scope, None);
         let context_scope = v8::scope::ContextScope::new(context);
 
-        let source = v8::string::String::new(&handle_scope, r#""hello, " + "world""#);
+        let source = v8::string::String::new(&handle_scope, r#""hello, " + "world""#).to_local_checked();
 
         let mut script = v8::script::Script::compile(&context_scope, &source);
 
@@ -39,8 +39,8 @@ fn main() {
 
         test.set(
             &context_scope,
-            &v8::string::String::new(&handle_scope, "test"),
-            &v8::string::String::new(&handle_scope, "test"),
+            &v8::string::String::new(&handle_scope, "test").to_local_checked(),
+            &v8::string::String::new(&handle_scope, "test").to_local_checked(),
             None,
         );
 
@@ -48,7 +48,7 @@ fn main() {
             "{{ test: {} }}",
             test.get(
                 &context_scope,
-                &v8::string::String::new(&handle_scope, "test"),
+                &v8::string::String::new(&handle_scope, "test").to_local_checked(),
                 None
             )
             .cast::<v8::string::String>()

--- a/v8/src/cpp/v8.cc
+++ b/v8/src/cpp/v8.cc
@@ -742,14 +742,14 @@ extern "C"
 // v8::Script
 extern "C"
 {
-    void v8cxx__script_compile(v8::Local<v8::Script> *local_buf, const v8::Local<v8::Context> *context, const v8::Local<v8::String> *source)
+    void v8cxx__script_compile(v8::MaybeLocal<v8::Script> *maybe_local_buf, const v8::Local<v8::Context> *context, const v8::Local<v8::String> *source)
     {
-        new (local_buf) v8::Local<v8::Script>(v8::Script::Compile(*context, *source).ToLocalChecked());
+        new (maybe_local_buf) v8::MaybeLocal<v8::Script>(v8::Script::Compile(*context, *source));
     }
 
-    void v8cxx__script_run(v8::Local<v8::Value> *local_buf, v8::Script *script, const v8::Local<v8::Context> *context)
+    void v8cxx__script_run(v8::MaybeLocal<v8::Value> *maybe_local_buf, v8::Script *script, const v8::Local<v8::Context> *context)
     {
-        new (local_buf) v8::Local<v8::Value>(script->Run(*context).ToLocalChecked());
+        new (maybe_local_buf) v8::MaybeLocal<v8::Value>(script->Run(*context));
     }
 }
 

--- a/v8/src/cpp/v8.cc
+++ b/v8/src/cpp/v8.cc
@@ -522,34 +522,34 @@ extern "C"
         return value.IsModuleNamespaceObject();
     }
 
-    void v8cxx__value_to_primitive(v8::Local<v8::Primitive> *local_buf, const v8::Value &value, const v8::Local<v8::Context> *context)
+    void v8cxx__value_to_primitive(v8::MaybeLocal<v8::Primitive> *maybe_local_buf, const v8::Value &value, const v8::Local<v8::Context> *context)
     {
-        new (local_buf) v8::Local<v8::Primitive>(value.ToPrimitive(*context).ToLocalChecked());
+        new (maybe_local_buf) v8::Local<v8::Primitive>(value.ToPrimitive(*context).ToLocalChecked());
     }
 
-    void v8cxx__value_to_bigint(v8::Local<v8::BigInt> *local_buf, const v8::Value &value, const v8::Local<v8::Context> *context)
+    void v8cxx__value_to_bigint(v8::MaybeLocal<v8::BigInt> *maybe_local_buf, const v8::Value &value, const v8::Local<v8::Context> *context)
     {
-        new (local_buf) v8::Local<v8::BigInt>(value.ToBigInt(*context).ToLocalChecked());
+        new (maybe_local_buf) v8::Local<v8::BigInt>(value.ToBigInt(*context).ToLocalChecked());
     }
 
-    void v8cxx__value_to_number(v8::Local<v8::Number> *local_buf, const v8::Value &value, const v8::Local<v8::Context> *context)
+    void v8cxx__value_to_number(v8::MaybeLocal<v8::Number> *maybe_local_buf, const v8::Value &value, const v8::Local<v8::Context> *context)
     {
-        new (local_buf) v8::Local<v8::Number>(value.ToNumber(*context).ToLocalChecked());
+        new (maybe_local_buf) v8::Local<v8::Number>(value.ToNumber(*context).ToLocalChecked());
     }
 
-    void v8cxx__value_to_string(v8::Local<v8::String> *local_buf, const v8::Value &value, const v8::Local<v8::Context> *context)
+    void v8cxx__value_to_string(v8::MaybeLocal<v8::String> *maybe_local_buf, const v8::Value &value, const v8::Local<v8::Context> *context)
     {
-        new (local_buf) v8::Local<v8::String>(value.ToString(*context).ToLocalChecked());
+        new (maybe_local_buf) v8::Local<v8::String>(value.ToString(*context).ToLocalChecked());
     }
 
-    void v8cxx__value_to_object(v8::Local<v8::Object> *local_buf, const v8::Value &value, const v8::Local<v8::Context> *context)
+    void v8cxx__value_to_object(v8::MaybeLocal<v8::Object> *maybe_local_buf, const v8::Value &value, const v8::Local<v8::Context> *context)
     {
-        new (local_buf) v8::Local<v8::Object>(value.ToObject(*context).ToLocalChecked());
+        new (maybe_local_buf) v8::Local<v8::Object>(value.ToObject(*context).ToLocalChecked());
     }
 
-    void v8cxx__value_to_boolean(v8::Local<v8::Boolean> *local_buf, const v8::Value &value, v8::Isolate *isolate)
+    void v8cxx__value_to_boolean(v8::MaybeLocal<v8::Boolean> *maybe_local_buf, const v8::Value &value, v8::Isolate *isolate)
     {
-        new (local_buf) v8::Local<v8::Boolean>(value.ToBoolean(isolate));
+        new (maybe_local_buf) v8::Local<v8::Boolean>(value.ToBoolean(isolate));
     }
 
     void v8cxx__value_typeof(v8::Local<v8::String> *local_buf, v8::Value &value, v8::Isolate *isolate)

--- a/v8/src/cpp/v8.cc
+++ b/v8/src/cpp/v8.cc
@@ -769,23 +769,17 @@ extern "C"
     {
         new (local_buf) v8::Local<v8::Object>(v8::Object::New(isolate));
     }
+
     bool v8cxx__object_set(
         v8::Object *object,
         const v8::Local<v8::Context> *context,
         const v8::Local<v8::Value> *key,
         const v8::Local<v8::Value> *value,
-        const v8::Local<v8::Object> *receiver)
+        const v8::MaybeLocal<v8::Object> *receiver)
     {
         auto result = false;
 
-        if (receiver == nullptr)
-        {
-            object->Set(*context, *key, *value).FromMaybe(&result);
-        }
-        else
-        {
-            object->Set(*context, *key, *value, *receiver).FromMaybe(&result);
-        }
+        object->Set(*context, *key, *value, *receiver).FromMaybe(&result);
 
         return result;
     }
@@ -846,29 +840,22 @@ extern "C"
     // TODO: v8cxx__object_define_property
 
     void v8cxx__object_get(
-        v8::Local<v8::Value> *local_buf,
+        v8::MaybeLocal<v8::Value> *local_buf,
         v8::Object *object,
         const v8::Local<v8::Context> *context,
         const v8::Local<v8::Value> *key,
-        const v8::Local<v8::Object> *receiver)
+        const v8::MaybeLocal<v8::Object> *receiver)
     {
-        if (receiver == nullptr)
-        {
-            new (local_buf) v8::Local<v8::Value>(object->Get(*context, *key).ToLocalChecked());
-        }
-        else
-        {
-            new (local_buf) v8::Local<v8::Value>(object->Get(*context, *key, *receiver).ToLocalChecked());
-        }
+        new (local_buf) v8::MaybeLocal<v8::Value>(object->Get(*context, *key, *receiver));
     }
 
     void v8cxx__object_get_indexed(
-        v8::Local<v8::Value> *local_buf,
+        v8::MaybeLocal<v8::Value> *local_buf,
         v8::Object *object,
         const v8::Local<v8::Context> *context,
         uint32_t index)
     {
-        new (local_buf) v8::Local<v8::Value>(object->Get(*context, index).ToLocalChecked());
+        new (local_buf) v8::MaybeLocal<v8::Value>(object->Get(*context, index));
     }
 }
 
@@ -912,6 +899,15 @@ extern "C"
     int v8cxx__module_get_identity_hash(const v8::Module *module)
     {
         return module->GetIdentityHash();
+    }
+}
+
+// v8::Local
+extern "C"
+{
+    void v8cxx__local_empty(v8::Local<v8::Data> *local_buf)
+    {
+        new (local_buf) v8::Local<v8::Data>();
     }
 }
 

--- a/v8/src/cpp/v8.cc
+++ b/v8/src/cpp/v8.cc
@@ -524,32 +524,32 @@ extern "C"
 
     void v8cxx__value_to_primitive(v8::MaybeLocal<v8::Primitive> *maybe_local_buf, const v8::Value &value, const v8::Local<v8::Context> *context)
     {
-        new (maybe_local_buf) v8::Local<v8::Primitive>(value.ToPrimitive(*context).ToLocalChecked());
+        new (maybe_local_buf) v8::MaybeLocal<v8::Primitive>(value.ToPrimitive(*context));
     }
 
     void v8cxx__value_to_bigint(v8::MaybeLocal<v8::BigInt> *maybe_local_buf, const v8::Value &value, const v8::Local<v8::Context> *context)
     {
-        new (maybe_local_buf) v8::Local<v8::BigInt>(value.ToBigInt(*context).ToLocalChecked());
+        new (maybe_local_buf) v8::MaybeLocal<v8::BigInt>(value.ToBigInt(*context));
     }
 
     void v8cxx__value_to_number(v8::MaybeLocal<v8::Number> *maybe_local_buf, const v8::Value &value, const v8::Local<v8::Context> *context)
     {
-        new (maybe_local_buf) v8::Local<v8::Number>(value.ToNumber(*context).ToLocalChecked());
+        new (maybe_local_buf) v8::MaybeLocal<v8::Number>(value.ToNumber(*context));
     }
 
     void v8cxx__value_to_string(v8::MaybeLocal<v8::String> *maybe_local_buf, const v8::Value &value, const v8::Local<v8::Context> *context)
     {
-        new (maybe_local_buf) v8::Local<v8::String>(value.ToString(*context).ToLocalChecked());
+        new (maybe_local_buf) v8::MaybeLocal<v8::String>(value.ToString(*context));
     }
 
     void v8cxx__value_to_object(v8::MaybeLocal<v8::Object> *maybe_local_buf, const v8::Value &value, const v8::Local<v8::Context> *context)
     {
-        new (maybe_local_buf) v8::Local<v8::Object>(value.ToObject(*context).ToLocalChecked());
+        new (maybe_local_buf) v8::MaybeLocal<v8::Object>(value.ToObject(*context));
     }
 
-    void v8cxx__value_to_boolean(v8::MaybeLocal<v8::Boolean> *maybe_local_buf, const v8::Value &value, v8::Isolate *isolate)
+    void v8cxx__value_to_boolean(v8::Local<v8::Boolean> *local_buf, const v8::Value &value, v8::Isolate *isolate)
     {
-        new (maybe_local_buf) v8::Local<v8::Boolean>(value.ToBoolean(isolate));
+        new (local_buf) v8::Local<v8::Boolean>(value.ToBoolean(isolate));
     }
 
     void v8cxx__value_typeof(v8::Local<v8::String> *local_buf, v8::Value &value, v8::Isolate *isolate)

--- a/v8/src/cpp/v8.cc
+++ b/v8/src/cpp/v8.cc
@@ -840,22 +840,22 @@ extern "C"
     // TODO: v8cxx__object_define_property
 
     void v8cxx__object_get(
-        v8::MaybeLocal<v8::Value> *local_buf,
+        v8::MaybeLocal<v8::Value> *maybe_local_buf,
         v8::Object *object,
         const v8::Local<v8::Context> *context,
         const v8::Local<v8::Value> *key,
         const v8::MaybeLocal<v8::Object> *receiver)
     {
-        new (local_buf) v8::MaybeLocal<v8::Value>(object->Get(*context, *key, *receiver));
+        new (maybe_local_buf) v8::MaybeLocal<v8::Value>(object->Get(*context, *key, *receiver));
     }
 
     void v8cxx__object_get_indexed(
-        v8::MaybeLocal<v8::Value> *local_buf,
+        v8::MaybeLocal<v8::Value> *maybe_local_buf,
         v8::Object *object,
         const v8::Local<v8::Context> *context,
         uint32_t index)
     {
-        new (local_buf) v8::MaybeLocal<v8::Value>(object->Get(*context, index));
+        new (maybe_local_buf) v8::MaybeLocal<v8::Value>(object->Get(*context, index));
     }
 }
 

--- a/v8/src/cpp/v8.cc
+++ b/v8/src/cpp/v8.cc
@@ -594,19 +594,19 @@ extern "C"
 // v8::String
 extern "C"
 {
-    void v8cxx__string_new_from_utf8(v8::Local<v8::String> *local_buf, v8::Isolate *isolate, const char *value, v8::NewStringType type, int length)
+    void v8cxx__string_new_from_utf8(v8::MaybeLocal<v8::String> *maybe_local_buf, v8::Isolate *isolate, const char *value, v8::NewStringType type, int length)
     {
-        new (local_buf) v8::Local<v8::String>(v8::String::NewFromUtf8(isolate, value, type, length).ToLocalChecked());
+        new (maybe_local_buf) v8::MaybeLocal<v8::String>(v8::String::NewFromUtf8(isolate, value, type, length));
     }
 
-    void v8cxx__string_new_from_onebyte(v8::Local<v8::String> *local_buf, v8::Isolate *isolate, const uint8_t *value, v8::NewStringType type, int length)
+    void v8cxx__string_new_from_onebyte(v8::MaybeLocal<v8::String> *maybe_local_buf, v8::Isolate *isolate, const uint8_t *value, v8::NewStringType type, int length)
     {
-        new (local_buf) v8::Local<v8::String>(v8::String::NewFromOneByte(isolate, value, type, length).ToLocalChecked());
+        new (maybe_local_buf) v8::MaybeLocal<v8::String>(v8::String::NewFromOneByte(isolate, value, type, length));
     }
 
-    void v8cxx__string_new_from_twobyte(v8::Local<v8::String> *local_buf, v8::Isolate *isolate, const uint16_t *value, v8::NewStringType type, int length)
+    void v8cxx__string_new_from_twobyte(v8::MaybeLocal<v8::String> *maybe_local_buf, v8::Isolate *isolate, const uint16_t *value, v8::NewStringType type, int length)
     {
-        new (local_buf) v8::Local<v8::String>(v8::String::NewFromTwoByte(isolate, value, type, length).ToLocalChecked());
+        new (maybe_local_buf) v8::MaybeLocal<v8::String>(v8::String::NewFromTwoByte(isolate, value, type, length));
     }
 
     int v8cxx__string_length(const v8::String &string)

--- a/v8/src/cpp/v8.cc
+++ b/v8/src/cpp/v8.cc
@@ -885,3 +885,56 @@ extern "C"
         new (local_buf) v8::Local<v8::Data>(fixed_array->Get(*context, i));
     }
 }
+
+// v8::Module
+extern "C"
+{
+    v8::Module::Status v8cxx__module_get_status(const v8::Module *module)
+    {
+        return module->GetStatus();
+    }
+
+    void v8cxx__module_get_exception(v8::Local<v8::Value> *local_buf, const v8::Module *module)
+    {
+        new (local_buf) v8::Local<v8::Value>(module->GetException());
+    }
+
+    void v8cxx__module_get_module_requests(v8::Local<v8::FixedArray> *local_buf, const v8::Module *module)
+    {
+        new (local_buf) v8::Local<v8::FixedArray>(module->GetModuleRequests());
+    }
+
+    v8::Location v8cxx__module_source_offset_to_location(const v8::Module *module, int offset)
+    {
+        return module->SourceOffsetToLocation(offset);
+    }
+
+    int v8cxx__module_get_identity_hash(const v8::Module *module)
+    {
+        return module->GetIdentityHash();
+    }
+}
+
+// v8::MaybeLocal
+extern "C"
+{
+    bool v8cxx__maybe_local_is_empty(const v8::MaybeLocal<v8::Data> *maybe_local)
+    {
+        return maybe_local->IsEmpty();
+    }
+
+    bool v8cxx__maybe_local_to_local(const v8::MaybeLocal<v8::Data> *maybe_local, v8::Local<v8::Data> *out)
+    {
+        return maybe_local->ToLocal(out);
+    }
+
+    void v8cxx__maybe_local_to_local_checked(v8::Local<v8::Data> *local_buf, v8::MaybeLocal<v8::Data> *maybe_local)
+    {
+        new (local_buf) v8::Local<v8::Data>(maybe_local->ToLocalChecked());
+    }
+
+    void v8cxx__maybe_local_from_maybe(v8::Local<v8::Data> *local_buf, const v8::MaybeLocal<v8::Data> *maybe_local, const v8::Local<v8::Data> *default_value)
+    {
+        new (local_buf) v8::Local<v8::Data>(maybe_local->FromMaybe(*default_value));
+    }
+}

--- a/v8/src/fixed_array.rs
+++ b/v8/src/fixed_array.rs
@@ -33,6 +33,37 @@ impl FixedArray {
 
         local_data
     }
+
+    #[inline(always)]
+    pub fn iter<'a>(&'a self, context: &'a Local<Context>) -> FixedArrayIterator<'a> {
+        FixedArrayIterator {
+            fixed_array: self,
+            context,
+            index: 0,
+        }
+    }
 }
 
 impl Data for FixedArray {}
+
+pub struct FixedArrayIterator<'a> {
+    fixed_array: &'a FixedArray,
+    context: &'a Local<Context>,
+    index: isize,
+}
+
+impl<'a> Iterator for FixedArrayIterator<'a> {
+    type Item = Local<data::Data>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index >= self.fixed_array.length() as isize {
+            None
+        } else {
+            let index = self.index;
+
+            self.index += 1;
+
+            Some(self.fixed_array.get(self.context, index as i32))
+        }
+    }
+}

--- a/v8/src/lib.rs
+++ b/v8/src/lib.rs
@@ -14,6 +14,7 @@ pub mod fixed_array;
 pub mod isolate;
 pub mod local;
 pub mod microtask_queue;
+pub mod module;
 pub mod name;
 pub mod number;
 pub mod numeric;

--- a/v8/src/local.rs
+++ b/v8/src/local.rs
@@ -6,13 +6,21 @@ use std::{
 
 use crate::data::{self, traits::Data};
 
+extern "C" {
+    fn v8cxx__local_empty(local_buf: *mut Local<data::Data>);
+}
+
 #[repr(C)]
 pub struct Local<T: Data>(NonNull<T>);
 
 impl<T: Data> Local<T> {
     #[inline(always)]
     pub fn empty() -> Self {
-        Self(NonNull::dangling())
+        let mut local = Self(NonNull::dangling());
+
+        unsafe { v8cxx__local_empty(local.cast_mut()) };
+
+        local
     }
 
     #[inline(always)]
@@ -72,6 +80,11 @@ extern "C" {
 pub struct MaybeLocal<T: Data>(Local<T>);
 
 impl<T: Data> MaybeLocal<T> {
+    #[inline(always)]
+    pub fn empty() -> Self {
+        Self(Local::empty())
+    }
+
     #[inline(always)]
     pub fn cast<U: Data>(self) -> MaybeLocal<U> {
         MaybeLocal(self.0.cast())

--- a/v8/src/local.rs
+++ b/v8/src/local.rs
@@ -4,7 +4,7 @@ use std::{
     ptr::NonNull,
 };
 
-use crate::data::traits::Data;
+use crate::data::{self, traits::Data};
 
 #[repr(C)]
 pub struct Local<T: Data>(NonNull<T>);
@@ -48,5 +48,76 @@ impl<T: Data> DerefMut for Local<T> {
 impl<T: Data> Drop for Local<T> {
     fn drop(&mut self) {
         unsafe { self.0.drop_in_place() };
+    }
+}
+
+extern "C" {
+    fn v8cxx__maybe_local_is_empty(this: *const MaybeLocal<data::Data>) -> bool;
+    fn v8cxx__maybe_local_to_local(
+        this: *const MaybeLocal<data::Data>,
+        out: *mut Local<data::Data>,
+    ) -> bool;
+    fn v8cxx__maybe_local_to_local_checked(
+        local_buf: *mut Local<data::Data>,
+        this: *mut MaybeLocal<data::Data>,
+    );
+    fn v8cxx__maybe_local_from_maybe(
+        local_buf: *mut Local<data::Data>,
+        this: *const MaybeLocal<data::Data>,
+        default_value: *const Local<data::Data>,
+    );
+}
+
+#[repr(C)]
+pub struct MaybeLocal<T: Data>(Local<T>);
+
+impl<T: Data> MaybeLocal<T> {
+    #[inline(always)]
+    pub fn cast<U: Data>(self) -> MaybeLocal<U> {
+        MaybeLocal(self.0.cast())
+    }
+
+    #[inline(always)]
+    pub fn cast_ref<U: Data>(&self) -> &MaybeLocal<U> {
+        unsafe { transmute(self) }
+    }
+
+    #[inline(always)]
+    pub fn cast_mut<U: Data>(&mut self) -> &mut MaybeLocal<U> {
+        unsafe { transmute(self) }
+    }
+
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        unsafe { v8cxx__maybe_local_is_empty(self.cast_ref()) }
+    }
+
+    #[inline(always)]
+    pub fn to_local(&self, out: &mut Local<impl Data>) -> bool {
+        unsafe { v8cxx__maybe_local_to_local(self.cast_ref(), out.cast_mut()) }
+    }
+
+    #[inline(always)]
+    pub fn to_local_checked(&mut self) -> Local<T> {
+        let mut local_data = Local::<T>::empty();
+
+        unsafe { v8cxx__maybe_local_to_local_checked(local_data.cast_mut(), self.cast_mut()) };
+
+        local_data
+    }
+
+    #[inline(always)]
+    pub fn from_maybe<U: Data>(&self, default_value: &Local<U>) -> Local<U> {
+        let mut local_data = Local::<U>::empty();
+
+        unsafe {
+            v8cxx__maybe_local_from_maybe(
+                local_data.cast_mut(),
+                self.cast_ref(),
+                default_value.cast_ref(),
+            )
+        };
+
+        local_data
     }
 }

--- a/v8/src/module.rs
+++ b/v8/src/module.rs
@@ -1,0 +1,25 @@
+use crate::data::traits::Data;
+
+extern "C" {}
+
+#[repr(C)]
+pub struct Module([u8; 0]);
+
+impl Module {}
+
+impl Data for Module {}
+
+#[repr(C)]
+pub struct Location(i32, i32);
+
+impl Location {
+    #[inline(always)]
+    pub const fn line_number(&self) -> i32 {
+        self.0
+    }
+
+    #[inline(always)]
+    pub const fn column_number(&self) -> i32 {
+        self.1
+    }
+}

--- a/v8/src/object.rs
+++ b/v8/src/object.rs
@@ -2,7 +2,7 @@ use crate::{
     context::Context,
     data::traits::Data,
     isolate::Isolate,
-    local::Local,
+    local::{Local, MaybeLocal},
     name::Name,
     scope::HandleScope,
     value::{self, Value},
@@ -15,7 +15,7 @@ extern "C" {
         context: *const Local<Context>,
         key: *const Local<value::Value>,
         value: *const Local<value::Value>,
-        receiver: *const Local<Object>,
+        receiver: *const MaybeLocal<Object>,
     ) -> bool;
     fn v8cxx__object_set_indexed(
         this: *mut Object,
@@ -43,11 +43,17 @@ extern "C" {
         attributes: PropertyAttribute,
     ) -> bool;
     fn v8cxx__object_get(
-        local_buf: *mut Local<Value>,
+        maybe_local_buf: *mut MaybeLocal<Value>,
         this: *mut Object,
         context: *const Local<Context>,
         key: *const Local<Value>,
-        receiver: *const Local<Object>,
+        receiver: *const MaybeLocal<Object>,
+    );
+    fn v8cxx__object_get_indexed(
+        maybe_local_buf: *mut MaybeLocal<Value>,
+        this: *mut Object,
+        context: *const Local<Context>,
+        index: u32,
     );
 }
 
@@ -91,7 +97,7 @@ pub mod traits {
             context: &Local<Context>,
             key: &Local<impl Value>,
             value: &Local<impl Value>,
-            receiver: Option<&Local<super::Object>>,
+            receiver: Option<&MaybeLocal<super::Object>>,
         ) {
             unsafe {
                 v8cxx__object_set(
@@ -99,10 +105,7 @@ pub mod traits {
                     context,
                     key.cast_ref(),
                     value.cast_ref(),
-                    match receiver {
-                        Some(receiver) => receiver,
-                        None => std::ptr::null::<Local<super::Object>>(),
-                    },
+                    receiver.unwrap_or(&MaybeLocal::empty()),
                 )
             };
         }
@@ -172,24 +175,40 @@ pub mod traits {
             &mut self,
             context: &Local<Context>,
             key: &Local<impl Value>,
-            receiver: Option<&Local<super::Object>>,
-        ) -> Local<value::Value> {
-            let mut local_value = Local::<value::Value>::empty();
+            receiver: Option<&MaybeLocal<super::Object>>,
+        ) -> MaybeLocal<value::Value> {
+            let mut maybe_local_value = MaybeLocal::<value::Value>::empty();
 
             unsafe {
                 v8cxx__object_get(
-                    &mut local_value,
+                    &mut maybe_local_value,
                     self as *mut _ as *mut _,
                     context,
                     key.cast_ref(),
-                    match receiver {
-                        Some(receiver) => receiver,
-                        None => std::ptr::null::<Local<super::Object>>(),
-                    },
+                    receiver.unwrap_or(&MaybeLocal::empty()),
                 );
             }
 
-            local_value
+            maybe_local_value
+        }
+
+        fn get_indexed(
+            &mut self,
+            context: &Local<Context>,
+            index: u32,
+        ) -> MaybeLocal<value::Value> {
+            let mut maybe_local_value = MaybeLocal::empty();
+
+            unsafe {
+                v8cxx__object_get_indexed(
+                    &mut maybe_local_value,
+                    self as *mut _ as *mut _,
+                    context,
+                    index,
+                );
+            }
+
+            maybe_local_value
         }
     }
 }

--- a/v8/src/script.rs
+++ b/v8/src/script.rs
@@ -1,14 +1,14 @@
-use crate::{context::Context, data::traits::Data, local::Local, string::String, value::Value};
+use crate::{context::Context, data::traits::Data, local::{Local, MaybeLocal}, string::String, value::Value};
 
 extern "C" {
     fn v8cxx__script_compile(
-        local_buf: *mut Local<Script>,
+        maybe_local_buf: *mut MaybeLocal<Script>,
         context: *const Local<Context>,
         source: *const Local<String>,
     );
 
     fn v8cxx__script_run(
-        local_buf: *mut Local<Value>,
+        maybe_local_buf: *mut MaybeLocal<Value>,
         script: *mut Script,
         context: *const Local<Context>,
     );
@@ -19,23 +19,23 @@ pub struct Script([u8; 0]);
 
 impl Script {
     #[inline(always)]
-    pub fn compile(context: &Local<Context>, source: &Local<String>) -> Local<Self> {
-        let mut local_script = Local::<Self>::empty();
+    pub fn compile(context: &Local<Context>, source: &Local<String>) -> MaybeLocal<Self> {
+        let mut maybe_local_script = MaybeLocal::<Self>::empty();
 
-        unsafe { v8cxx__script_compile(&mut local_script, context, source) };
+        unsafe { v8cxx__script_compile(&mut maybe_local_script, context, source) };
 
-        local_script
+        maybe_local_script
     }
 
     #[inline(always)]
-    pub fn run(&mut self, context: &Local<Context>) -> Local<Value> {
-        let mut local_value = Local::<Value>::empty();
+    pub fn run(&mut self, context: &Local<Context>) -> MaybeLocal<Value> {
+        let mut maybe_local_value = MaybeLocal::<Value>::empty();
 
         unsafe {
-            v8cxx__script_run(&mut local_value, self, context);
+            v8cxx__script_run(&mut maybe_local_value, self, context);
         }
 
-        local_value
+        maybe_local_value
     }
 }
 

--- a/v8/src/string.rs
+++ b/v8/src/string.rs
@@ -1,13 +1,13 @@
 use core::str;
 
 use crate::{
-    data::traits::Data, isolate::Isolate, local::Local, primitive::traits::Primitive,
+    data::traits::Data, isolate::Isolate, local::{Local, MaybeLocal}, primitive::traits::Primitive,
     scope::HandleScope, value::traits::Value,
 };
 
 extern "C" {
     fn v8cxx__string_new_from_utf8(
-        local_buf: *mut Local<String>,
+        maybe_local_buf: *mut MaybeLocal<String>,
         isolate: *mut Isolate,
         value: *const u8,
         string_type: NewStringType,
@@ -15,7 +15,7 @@ extern "C" {
     );
 
     fn v8cxx__string_new_from_onebyte(
-        local_buf: *mut Local<String>,
+        maybe_local_buf: *mut MaybeLocal<String>,
         isolate: *mut Isolate,
         value: *const u8,
         string_type: NewStringType,
@@ -23,7 +23,7 @@ extern "C" {
     );
 
     fn v8cxx__string_new_from_twobyte(
-        local_buf: *mut Local<String>,
+        maybe_local_buf: *mut MaybeLocal<String>,
         isolate: *mut Isolate,
         value: *const u16,
         string_type: NewStringType,
@@ -57,7 +57,7 @@ pub struct String([u8; 0]);
 
 impl String {
     #[inline(always)]
-    pub fn new(handle_scope: &HandleScope, value: &str) -> Local<Self> {
+    pub fn new(handle_scope: &HandleScope, value: &str) -> MaybeLocal<Self> {
         Self::new_from_utf8(handle_scope, value, NewStringType::Normal)
     }
 
@@ -66,12 +66,12 @@ impl String {
         handle_scope: &HandleScope,
         value: &str,
         string_type: NewStringType,
-    ) -> Local<Self> {
-        let mut local_string = Local::<Self>::empty();
+    ) -> MaybeLocal<Self> {
+        let mut maybe_local_string = MaybeLocal::<Self>::empty();
 
         unsafe {
             v8cxx__string_new_from_utf8(
-                &mut local_string,
+                &mut maybe_local_string,
                 handle_scope.get_isolate().unwrap(),
                 value.as_ptr(),
                 string_type,
@@ -79,7 +79,7 @@ impl String {
             );
         }
 
-        local_string
+        maybe_local_string
     }
 
     #[inline(always)]
@@ -87,12 +87,12 @@ impl String {
         handle_scope: &HandleScope,
         value: &[u8],
         string_type: NewStringType,
-    ) -> Local<Self> {
-        let mut local_string = Local::<Self>::empty();
+    ) -> MaybeLocal<Self> {
+        let mut maybe_local_string = MaybeLocal::<Self>::empty();
 
         unsafe {
             v8cxx__string_new_from_onebyte(
-                &mut local_string,
+                &mut maybe_local_string,
                 handle_scope.get_isolate().unwrap(),
                 value.as_ptr(),
                 string_type,
@@ -100,7 +100,7 @@ impl String {
             );
         }
 
-        local_string
+        maybe_local_string
     }
 
     #[inline(always)]
@@ -108,12 +108,12 @@ impl String {
         handle_scope: &HandleScope,
         value: &[u16],
         string_type: NewStringType,
-    ) -> Local<Self> {
-        let mut local_string = Local::<Self>::empty();
+    ) -> MaybeLocal<Self> {
+        let mut maybe_local_string = MaybeLocal::<Self>::empty();
 
         unsafe {
             v8cxx__string_new_from_twobyte(
-                &mut local_string,
+                &mut maybe_local_string,
                 handle_scope.get_isolate().unwrap(),
                 value.as_ptr(),
                 string_type,
@@ -121,7 +121,7 @@ impl String {
             );
         }
 
-        local_string
+        maybe_local_string
     }
 
     #[inline(always)]

--- a/v8/src/value.rs
+++ b/v8/src/value.rs
@@ -1,6 +1,14 @@
 use crate::{
-    bigint::BigInt, boolean::Boolean, context::Context, data::traits::Data, isolate::Isolate,
-    local::Local, number::Number, object::Object, primitive::Primitive, string::String,
+    bigint::BigInt,
+    boolean::Boolean,
+    context::Context,
+    data::traits::Data,
+    isolate::Isolate,
+    local::{Local, MaybeLocal},
+    number::Number,
+    object::Object,
+    primitive::Primitive,
+    string::String,
 };
 
 extern "C" {
@@ -64,36 +72,40 @@ extern "C" {
     fn v8cxx__value_is_wasm_null(value: *const Value) -> bool;
     fn v8cxx__value_is_module_namespace_object(value: *const Value) -> bool;
     fn v8cxx__value_to_primitive(
-        local_buf: *mut Local<Primitive>,
+        maybe_local_buf: *mut MaybeLocal<Primitive>,
         value: *const Value,
         context: *const Local<Context>,
     );
     fn v8cxx__value_to_bigint(
-        local_buf: *mut Local<BigInt>,
+        maybe_local_buf: *mut MaybeLocal<BigInt>,
         value: *const Value,
         context: *const Local<Context>,
     );
     fn v8cxx__value_to_number(
-        local_buf: *mut Local<Number>,
+        maybe_local_buf: *mut MaybeLocal<Number>,
         value: *const Value,
         context: *const Local<Context>,
     );
     fn v8cxx__value_to_string(
-        local_buf: *mut Local<String>,
+        maybe_local_buf: *mut MaybeLocal<String>,
         value: *const Value,
         context: *const Local<Context>,
     );
     fn v8cxx__value_to_object(
-        local_buf: *mut Local<Object>,
+        maybe_local_buf: *mut MaybeLocal<Object>,
         value: *const Value,
         context: *const Local<Context>,
     );
     fn v8cxx__value_to_boolean(
-        local_buf: *mut Local<Boolean>,
+        maybe_local_buf: *mut MaybeLocal<Boolean>,
         value: *const Value,
         context: *const Local<Context>,
     );
-    fn v8cxx__value_typeof(local_buf: *mut Local<String>, value: *mut Value, isolate: *mut Isolate);
+    fn v8cxx__value_typeof(
+        local_buf: *mut Local<String>,
+        value: *mut Value,
+        isolate: *mut Isolate,
+    );
     fn v8cxx__value_instanceof(
         this: *const Value,
         context: *const Local<Context>,
@@ -352,72 +364,80 @@ pub mod traits {
             unsafe { v8cxx__value_is_module_namespace_object(self as *const _ as *const _) }
         }
 
-        fn to_primitive(&self, context: &Local<Context>) -> Local<Primitive> {
-            let mut local_primitive = Local::<Primitive>::empty();
+        fn to_primitive(&self, context: &Local<Context>) -> MaybeLocal<Primitive> {
+            let mut maybe_local_primitive = MaybeLocal::<Primitive>::empty();
 
             unsafe {
                 v8cxx__value_to_primitive(
-                    &mut local_primitive,
+                    &mut maybe_local_primitive,
                     self as *const _ as *const _,
                     context,
                 );
             }
 
-            local_primitive
+            maybe_local_primitive
         }
 
-        fn to_bigint(&self, context: &Local<Context>) -> Local<BigInt> {
-            let mut local_primitive = Local::<BigInt>::empty();
+        fn to_bigint(&self, context: &Local<Context>) -> MaybeLocal<BigInt> {
+            let mut maybe_local_bigint = MaybeLocal::<BigInt>::empty();
 
             unsafe {
-                v8cxx__value_to_bigint(&mut local_primitive, self as *const _ as *const _, context);
+                v8cxx__value_to_bigint(
+                    &mut maybe_local_bigint,
+                    self as *const _ as *const _,
+                    context,
+                );
             }
 
-            local_primitive
+            maybe_local_bigint
         }
 
-        fn to_number(&self, context: &Local<Context>) -> Local<Number> {
-            let mut local_primitive = Local::<Number>::empty();
+        fn to_number(&self, context: &Local<Context>) -> MaybeLocal<Number> {
+            let mut maybe_local_number = MaybeLocal::<Number>::empty();
 
             unsafe {
-                v8cxx__value_to_number(&mut local_primitive, self as *const _ as *const _, context);
+                v8cxx__value_to_number(
+                    &mut maybe_local_number,
+                    self as *const _ as *const _,
+                    context,
+                );
             }
 
-            local_primitive
+            maybe_local_number
         }
 
-        fn to_string(&self, context: &Local<Context>) -> Local<String> {
-            let mut local_primitive = Local::<String>::empty();
+        fn to_string(&self, context: &Local<Context>) -> MaybeLocal<String> {
+            let mut maybe_local_string = MaybeLocal::<String>::empty();
 
             unsafe {
-                v8cxx__value_to_string(&mut local_primitive, self as *const _ as *const _, context);
+                v8cxx__value_to_string(&mut maybe_local_string, self as *const _ as *const _, context);
             }
 
-            local_primitive
+            maybe_local_string
         }
 
-        fn to_object(&self, context: &Local<Context>) -> Local<Object> {
-            let mut local_primitive = Local::<Object>::empty();
+        fn to_object(&self, context: &Local<Context>) -> MaybeLocal<Object> {
+            let mut maybe_local_object = MaybeLocal::<Object>::empty();
 
             unsafe {
-                v8cxx__value_to_object(&mut local_primitive, self as *const _ as *const _, context);
+                v8cxx__value_to_object(&mut maybe_local_object, self as *const _ as *const _, context);
             }
 
-            local_primitive
+            maybe_local_object
         }
 
-        fn to_boolean(&self, context: &Local<Context>) -> Local<Boolean> {
-            let mut local_primitive = Local::<Boolean>::empty();
+        fn to_boolean(&self, context: &Local<Context>) -> MaybeLocal<Boolean> {
+            let mut local_boolean = MaybeLocal::<Boolean>::empty();
 
             unsafe {
                 v8cxx__value_to_boolean(
-                    &mut local_primitive,
+                    &mut local_boolean,
                     self as *const _ as *const _,
                     context,
                 );
             }
 
-            local_primitive
+            local_boolean
         }
 
         fn type_of(&mut self, isolate: &mut Isolate) -> Local<String> {

--- a/v8/src/value.rs
+++ b/v8/src/value.rs
@@ -97,7 +97,7 @@ extern "C" {
         context: *const Local<Context>,
     );
     fn v8cxx__value_to_boolean(
-        maybe_local_buf: *mut MaybeLocal<Boolean>,
+        local_buf: *mut Local<Boolean>,
         value: *const Value,
         context: *const Local<Context>,
     );
@@ -426,8 +426,8 @@ pub mod traits {
             maybe_local_object
         }
 
-        fn to_boolean(&self, context: &Local<Context>) -> MaybeLocal<Boolean> {
-            let mut local_boolean = MaybeLocal::<Boolean>::empty();
+        fn to_boolean(&self, context: &Local<Context>) -> Local<Boolean> {
+            let mut local_boolean = Local::<Boolean>::empty();
 
             unsafe {
                 v8cxx__value_to_boolean(


### PR DESCRIPTION
In this PR the following things were done:
- added `FixedArrayIterator` for `FixedArray`

- added `v8::Module` struct (partial functionality)
- added `v8::MaybeLocal` struct
- now `Local<T>` is constructed on C++ side
- changed naming for `v8cxx__object_*` functions
- now `Value::to_*` returns `MaybeLocal` as it should
- now `v8cxx__value_to_*` returns correct type
- now core builds correct
- now `String::new_*` returns `MaybeLocal<String>`
- now `Script::compile` and `Script::run` returns `MaybeLocal`