### PR TITLE
fix(V8): now v8cxx__module_request_get_phase returns value as expected

### DIFF
--- a/v8/src/cpp/v8.cc
+++ b/v8/src/cpp/v8.cc
@@ -929,7 +929,7 @@ void v8cxx__module_request_get_specifier(
 
 v8::ModuleImportPhase v8cxx__module_request_get_phase(
     const v8::ModuleRequest* module_request) {
-  module_request->GetPhase();
+  return module_request->GetPhase();
 }
 
 void v8cxx__module_request_get_import_attributes(


### PR DESCRIPTION
In this PR was added missing return keyword in `v8cxx__module_request_get_phase` which caused a fail of the build.