### PR TITLE
feat(V8): added get_resource_name method for v8::Script struct

### DIFF
--- a/v8/src/cpp/v8.cc
+++ b/v8/src/cpp/v8.cc
@@ -673,6 +673,25 @@ void v8cxx__script_run(v8::MaybeLocal<v8::Value>* maybe_local_buf,
                        const v8::Local<v8::Context>* context) {
   new (maybe_local_buf) v8::MaybeLocal<v8::Value>(script->Run(*context));
 }
+
+// TODO: add this to v8::script::Script (Rust)
+void v8cxx__script_get_unbound_script(v8::Local<v8::UnboundScript>* local_buf,
+                                      v8::Script* script) {
+  new (local_buf) v8::Local<v8::UnboundScript>(script->GetUnboundScript());
+}
+
+void v8cxx__script_get_resource_name(v8::Local<v8::Value>* local_buf,
+                                     v8::Script* script) {
+  new (local_buf) v8::Local<v8::Value>(script->GetResourceName());
+}
+
+// TODO: add this to v8::script::Script (Rust)
+void v8cxx__script_get_compile_hints_collector(
+    v8::Local<v8::CompileHintsCollector>* local_buf,
+    const v8::Script* script) {
+  new (local_buf)
+      v8::Local<v8::CompileHintsCollector>(script->GetCompileHintsCollector());
+}
 }
 
 // v8::Name

--- a/v8/src/script.rs
+++ b/v8/src/script.rs
@@ -1,4 +1,10 @@
-use crate::{context::Context, data::traits::Data, local::{Local, MaybeLocal}, string::String, value::Value};
+use crate::{
+    context::Context,
+    data::traits::Data,
+    local::{Local, MaybeLocal},
+    string::String,
+    value::Value,
+};
 
 extern "C" {
     fn v8cxx__script_compile(
@@ -12,6 +18,8 @@ extern "C" {
         script: *mut Script,
         context: *const Local<Context>,
     );
+
+    fn v8cxx__script_get_resource_name(local_buf: *mut Local<Value>, script: *mut Script);
 }
 
 #[repr(C)]
@@ -20,7 +28,7 @@ pub struct Script([u8; 0]);
 impl Script {
     #[inline(always)]
     pub fn compile(context: &Local<Context>, source: &Local<String>) -> MaybeLocal<Self> {
-        let mut maybe_local_script = MaybeLocal::<Self>::empty();
+        let mut maybe_local_script = MaybeLocal::empty();
 
         unsafe { v8cxx__script_compile(&mut maybe_local_script, context, source) };
 
@@ -36,6 +44,15 @@ impl Script {
         }
 
         maybe_local_value
+    }
+
+    #[inline(always)]
+    pub fn get_resource_name(&mut self) -> Local<Value> {
+        let mut local_value = Local::empty();
+
+        unsafe { v8cxx__script_get_resource_name(&mut local_value, self) };
+
+        local_value
     }
 }
 


### PR DESCRIPTION
In this PR was added method `get_resource_name` for `v8::Script` struct.