### PR TITLE
feat(V8): added v8::Signature, v8::Template, v8::Array v8::FunctionCallbackInfo<T>, v8::FunctionTemplate, v8::Function, v8::Integer, v8::Number trait, v8::ObjectTemplate, v8::PropertyCallbackInfo<T>, v8::ReturnValue<T>, and v8::ScriptOrigin structs

### DIFF
--- a/v8/src/array.rs
+++ b/v8/src/array.rs
@@ -1,0 +1,60 @@
+use crate::{
+    data::traits::Data,
+    isolate::Isolate,
+    local::Local,
+    object::traits::Object,
+    value::{self, traits::Value},
+};
+
+extern "C" {
+    fn v8cxx__array_length(this: *const Array) -> u32;
+    fn v8cxx__array_new(local_buf: *mut Local<Array>, isolate: *mut Isolate, length: i32);
+    fn v8cxx__array_new_with_elements(
+        local_buf: *mut Local<Array>,
+        isolate: *mut Isolate,
+        elements: *const Local<value::Value>,
+        length: usize,
+    );
+}
+
+#[repr(C)]
+pub struct Array([u8; 0]);
+
+impl Array {
+    #[inline(always)]
+    pub fn new(isolate: &mut Isolate, length: i32) -> Local<Self> {
+        let mut local_array = Local::empty();
+
+        unsafe { v8cxx__array_new(&mut local_array, isolate, length) };
+
+        local_array
+    }
+
+    #[inline(always)]
+    pub fn new_with_elements(
+        isolate: &mut Isolate,
+        elements: &Vec<Local<value::Value>>,
+    ) -> Local<Self> {
+        let mut local_array = Local::empty();
+
+        unsafe {
+            v8cxx__array_new_with_elements(
+                &mut local_array,
+                isolate,
+                elements.as_ptr(),
+                elements.len(),
+            )
+        };
+
+        local_array
+    }
+
+    #[inline(always)]
+    pub fn length(&self) -> u32 {
+        unsafe { v8cxx__array_length(self) }
+    }
+}
+
+impl Data for Array {}
+impl Value for Array {}
+impl Object for Array {}

--- a/v8/src/cpp/v8.cc
+++ b/v8/src/cpp/v8.cc
@@ -1033,17 +1033,17 @@ void v8cxx__template_set(v8::Template* template_,
 }
 
 void v8cxx__template_set_private(v8::Template* template_,
-                                 const v8::Local<v8::Name>* name,
+                                 const v8::Local<v8::Private>* name,
                                  const v8::Local<v8::Data>* value,
                                  v8::PropertyAttribute attributes) {
   template_->SetPrivate(*name, *value, attributes);
 }
 
 void v8cxx__template_set_with_isolate(v8::Template* template_,
-                                  v8::Isolate* isolate,
-                                  const char* name,
-                                  const v8::Local<v8::Data>* value,
-                                  v8::PropertyAttribute attributes) {
+                                      v8::Isolate* isolate,
+                                      const char* name,
+                                      const v8::Local<v8::Data>* value,
+                                      v8::PropertyAttribute attributes) {
   template_->Set(isolate, name, *value, attributes);
 }
 
@@ -1057,9 +1057,527 @@ void v8cxx__template_set_accessor_property(
 }
 }
 
-// v8::FunctionTemplate 
+// v8::FunctionTemplate
 extern "C" {
-  void v8cxx__function_template_new(v8::FunctionTemplate* fn_template) {
+void v8cxx__function_template_new(
+    v8::Local<v8::FunctionTemplate>* local_buf,
+    v8::Isolate* isolate,
+    v8::FunctionCallback fn_callback,
+    const v8::Local<v8::Value>* data,
+    const v8::Local<v8::Signature>* signature,
+    int length,
+    v8::ConstructorBehavior behavior,
+    v8::SideEffectType side_effect_type
+    /* TODO: add CFunction and rest of params */) {
+  new (local_buf) v8::Local<v8::FunctionTemplate>(
+      v8::FunctionTemplate::New(isolate, fn_callback, *data, *signature, length,
+                                behavior, side_effect_type));
+}
 
-  }
+void v8cxx__function_template_get_function(
+    v8::MaybeLocal<v8::Function>* maybe_local_buf,
+    v8::FunctionTemplate* fn_template,
+    const v8::Local<v8::Context>* context) {
+  new (maybe_local_buf)
+      v8::MaybeLocal<v8::Function>(fn_template->GetFunction(*context));
+}
+
+void v8cxx__function_template_instance_template(
+    v8::Local<v8::ObjectTemplate>* local_buf,
+    v8::FunctionTemplate* fn_template) {
+  new (local_buf)
+      v8::Local<v8::ObjectTemplate>(fn_template->InstanceTemplate());
+}
+
+void v8cxx__function_template_inherit(
+    v8::FunctionTemplate* fn_template,
+    const v8::Local<v8::FunctionTemplate>* parent) {
+  fn_template->Inherit(*parent);
+}
+
+void v8cxx__function_template_prototype_template(
+    v8::Local<v8::ObjectTemplate>* local_buf,
+    v8::FunctionTemplate* fn_template) {
+  new (local_buf)
+      v8::Local<v8::ObjectTemplate>(fn_template->PrototypeTemplate());
+}
+
+void v8cxx__function_template_set_prototype_provider_template(
+    v8::FunctionTemplate* fn_template,
+    const v8::Local<v8::FunctionTemplate>* prototype_provider) {
+  fn_template->SetPrototypeProviderTemplate(*prototype_provider);
+}
+
+void v8cxx__function_template_set_class_name(
+    v8::FunctionTemplate* fn_template,
+    const v8::Local<v8::String>* name) {
+  fn_template->SetClassName(*name);
+}
+
+void v8cxx__function_template_set_interface_name(
+    v8::FunctionTemplate* fn_template,
+    const v8::Local<v8::String>* name) {
+  fn_template->SetInterfaceName(*name);
+}
+
+void v8cxx__function_template_read_only_prototype(
+    v8::FunctionTemplate* fn_template) {
+  fn_template->ReadOnlyPrototype();
+}
+
+void v8cxx__function_template_remove_prototype(
+    v8::FunctionTemplate* fn_template) {
+  fn_template->RemovePrototype();
+}
+
+bool v8cxx__funtion_template_has_instance(v8::FunctionTemplate* fn_template,
+                                          const v8::Local<v8::Value>* object) {
+  return fn_template->HasInstance(*object);
+}
+}
+
+// v8::Function
+extern "C" {
+void v8cxx__function_new(v8::MaybeLocal<v8::Function>* maybe_local_buf,
+                         const v8::Local<v8::Context>* context,
+                         v8::FunctionCallback callback,
+                         const v8::Local<v8::Value>* data,
+                         int length,
+                         v8::ConstructorBehavior behavior,
+                         v8::SideEffectType side_effect_type) {
+  new (maybe_local_buf) v8::MaybeLocal<v8::Function>(v8::Function::New(
+      *context, callback, *data, length, behavior, side_effect_type));
+}
+
+void v8cxx__function_new_instance(v8::MaybeLocal<v8::Object>* maybe_local_buf,
+                                  const v8::Function* function,
+                                  const v8::Local<v8::Context>* context,
+                                  int argc,
+                                  v8::Local<v8::Value>* argv) {
+  new (maybe_local_buf)
+      v8::MaybeLocal<v8::Object>(function->NewInstance(*context, argc, argv));
+}
+
+void v8cxx__function_new_instance_with_side_effect_type(
+    v8::MaybeLocal<v8::Object>* maybe_local_buf,
+    const v8::Function* function,
+    const v8::Local<v8::Context>* context,
+    int argc,
+    v8::Local<v8::Value>* argv,
+    v8::SideEffectType side_effect_type) {
+  new (maybe_local_buf)
+      v8::MaybeLocal<v8::Object>(function->NewInstanceWithSideEffectType(
+          *context, argc, argv, side_effect_type));
+}
+
+void v8cxx__function_set_name(v8::Function* function,
+                              const v8::Local<v8::String>* name) {
+  function->SetName(*name);
+}
+
+void v8cxx__function_get_name(v8::Local<v8::Value>* local_buf,
+                              const v8::Function* function) {
+  new (local_buf) v8::Local<v8::Value>(function->GetName());
+}
+
+void v8cxx__function_get_inferred_name(v8::Local<v8::Value>* local_buf,
+                                       const v8::Function* function) {
+  new (local_buf) v8::Local<v8::Value>(function->GetInferredName());
+}
+
+int v8cxx__function_get_script_line_number(const v8::Function* function) {
+  return function->GetScriptLineNumber();
+}
+
+int v8cxx__function_get_script_column_number(const v8::Function* function) {
+  return function->GetScriptColumnNumber();
+}
+
+int v8cxx__function_script_id(const v8::Function* function) {
+  return function->ScriptId();
+}
+
+void v8cxx__function_get_bound_function(v8::Local<v8::Value>* local_buf,
+                                        const v8::Function* function) {
+  new (local_buf) v8::Local<v8::Value>(function->GetBoundFunction());
+}
+
+void v8cxx__function_function_proto_to_string(
+    v8::MaybeLocal<v8::String>* maybe_local_buf,
+    v8::Function* function,
+    const v8::Local<v8::Context>* context) {
+  new (maybe_local_buf)
+      v8::MaybeLocal<v8::String>(function->FunctionProtoToString(*context));
+}
+
+void v8cxx__function_get_script_origin(v8::ScriptOrigin* buf,
+                                       const v8::Function* function) {
+  new (buf) v8::ScriptOrigin(function->GetScriptOrigin());
+}
+}
+
+// v8::FunctionCallbackInfo<T>
+extern "C" {
+int v8cxx__function_callback_info_length(
+    const v8::FunctionCallbackInfo<v8::Value>* fn_callback_info) {
+  return fn_callback_info->Length();
+}
+
+void v8cxx__function_callback_info_at(
+    v8::Local<v8::Value>* local_buf,
+    const v8::FunctionCallbackInfo<v8::Value>* fn_callback_info,
+    int index) {
+  new (local_buf) v8::Local<v8::Value>((*fn_callback_info)[index]);
+}
+
+void v8cxx__function_callback_info_this(
+    v8::Local<v8::Object>* local_buf,
+    const v8::FunctionCallbackInfo<v8::Value>* fn_callback_info) {
+  new (local_buf) v8::Local<v8::Object>(fn_callback_info->This());
+}
+
+void v8cxx__function_callback_info_new_target(
+    v8::Local<v8::Value>* local_buf,
+    const v8::FunctionCallbackInfo<v8::Value>* fn_callback_info) {
+  new (local_buf) v8::Local<v8::Value>(fn_callback_info->NewTarget());
+}
+
+bool v8cxx__function_callback_info_is_construct_call(
+    const v8::FunctionCallbackInfo<v8::Value>* fn_callback_info) {
+  return fn_callback_info->IsConstructCall();
+}
+
+void v8cxx__function_callback_info_data(
+    v8::Local<v8::Value>* local_buf,
+    const v8::FunctionCallbackInfo<v8::Value>* fn_callback_info) {
+  new (local_buf) v8::Local<v8::Value>(fn_callback_info->Data());
+}
+
+v8::Isolate* v8cxx__function_callback_info_get_isolate(
+    const v8::FunctionCallbackInfo<v8::Value>* fn_callback_info) {
+  return fn_callback_info->GetIsolate();
+}
+
+void v8cxx__function_callback_info_get_return_value(
+    v8::ReturnValue<v8::Value>* buf,
+    const v8::FunctionCallbackInfo<v8::Value>* fn_callback_info) {
+  new (buf) v8::ReturnValue<v8::Value>(fn_callback_info->GetReturnValue());
+}
+}
+
+// v8::ReturnValue<T>
+extern "C" {
+void v8cxx__return_value_set(v8::ReturnValue<v8::Value>* return_value,
+                             const v8::Local<v8::Value>* value) {
+  return_value->Set(*value);
+}
+
+void v8cxx__return_value_set_bool(v8::ReturnValue<v8::Value>* return_value,
+                                  bool value) {
+  return_value->Set(value);
+}
+
+void v8cxx__return_value_set_f64(v8::ReturnValue<v8::Value>* return_value,
+                                 double value) {
+  return_value->Set(value);
+}
+
+void v8cxx__return_value_set_i16(v8::ReturnValue<v8::Value>* return_value,
+                                 int16_t value) {
+  return_value->Set(value);
+}
+
+void v8cxx__return_value_set_i32(v8::ReturnValue<v8::Value>* return_value,
+                                 int32_t value) {
+  return_value->Set(value);
+}
+
+void v8cxx__return_value_set_i64(v8::ReturnValue<v8::Value>* return_value,
+                                 int64_t value) {
+  return_value->Set(value);
+}
+
+void v8cxx__return_value_set_u16(v8::ReturnValue<v8::Value>* return_value,
+                                 uint16_t value) {
+  return_value->Set(value);
+}
+
+void v8cxx__return_value_set_u32(v8::ReturnValue<v8::Value>* return_value,
+                                 uint32_t value) {
+  return_value->Set(value);
+}
+
+void v8cxx__return_value_set_u64(v8::ReturnValue<v8::Value>* return_value,
+                                 uint64_t value) {
+  return_value->Set(value);
+}
+
+void v8cxx__return_value_set_null(v8::ReturnValue<v8::Value>* return_value) {
+  return_value->SetNull();
+}
+
+void v8cxx__return_value_set_undefined(
+    v8::ReturnValue<v8::Value>* return_value) {
+  return_value->SetUndefined();
+}
+
+void v8cxx__return_value_set_false(v8::ReturnValue<v8::Value>* return_value) {
+  return_value->SetFalse();
+}
+
+void v8cxx__return_value_set_empty_string(
+    v8::ReturnValue<v8::Value>* return_value) {
+  return_value->SetEmptyString();
+}
+
+v8::Isolate* v8cxx__return_value_get_isolate(
+    const v8::ReturnValue<v8::Value>* return_value) {
+  return return_value->GetIsolate();
+}
+
+void v8cxx__return_value_get(v8::Local<v8::Value>* local_buf,
+                             const v8::ReturnValue<v8::Value>* return_value) {
+  new (local_buf) v8::Local<v8::Value>(return_value->Get());
+}
+}
+
+// v8::ScriptOrigin
+extern "C" {
+void v8cxx__script_origin_new(v8::ScriptOrigin* buf,
+                              const v8::Local<v8::Value>* resource_name,
+                              int resource_line_offset,
+                              int resource_column_offset,
+                              bool resource_is_shared_cross_origin,
+                              int script_id,
+                              const v8::Local<v8::Value>* source_map_url,
+                              bool resource_is_opaque,
+                              bool is_wasm,
+                              bool is_module,
+                              const v8::Local<v8::Data>* host_defined_options) {
+  new (buf) v8::ScriptOrigin(v8::ScriptOrigin(
+      *resource_name, resource_line_offset, resource_column_offset,
+      resource_is_shared_cross_origin, script_id, *source_map_url,
+      resource_is_opaque, is_wasm, is_module, *host_defined_options));
+}
+
+void v8cxx__script_origin_resource_name(v8::Local<v8::Value>* local_buf,
+                                        const v8::ScriptOrigin* script_origin) {
+  new (local_buf) v8::Local<v8::Value>(script_origin->ResourceName());
+}
+
+int v8cxx__script_origin_line_offset(const v8::ScriptOrigin* script_origin) {
+  return script_origin->LineOffset();
+}
+
+int v8cxx__script_origin_column_offset(const v8::ScriptOrigin* script_origin) {
+  return script_origin->ColumnOffset();
+}
+
+int v8cxx__script_origin_script_id(const v8::ScriptOrigin* script_origin) {
+  return script_origin->ScriptId();
+}
+
+void v8cxx__script_origin_source_map_url(
+    v8::Local<v8::Value>* local_buf,
+    const v8::ScriptOrigin* script_origin) {
+  new (local_buf) v8::Local<v8::Value>(script_origin->SourceMapUrl());
+}
+
+void v8cxx__script_origin_get_host_defined_options(
+    v8::Local<v8::Data>* local_buf,
+    const v8::ScriptOrigin* script_origin) {
+  new (local_buf) v8::Local<v8::Data>(script_origin->GetHostDefinedOptions());
+}
+
+bool v8cxx__script_origin_is_module(const v8::ScriptOrigin* script_origin) {
+  return script_origin->Options().IsModule();
+}
+
+bool v8cxx__script_origin_is_opaque(const v8::ScriptOrigin* script_origin) {
+  return script_origin->Options().IsOpaque();
+}
+
+bool v8cxx__script_origin_is_shared_cross_origin(
+    const v8::ScriptOrigin* script_origin) {
+  return script_origin->Options().IsSharedCrossOrigin();
+}
+
+bool v8cxx__script_origin_is_wasm(const v8::ScriptOrigin* script_origin) {
+  return script_origin->Options().IsWasm();
+}
+}
+
+// v8::ObjectTemplate
+extern "C" {
+void v8cxx__object_template_new(
+    v8::Local<v8::ObjectTemplate>* local_buf,
+    v8::Isolate* isolate,
+    const v8::Local<v8::FunctionTemplate>* constructor) {
+  new (local_buf) v8::Local<v8::ObjectTemplate>(
+      v8::ObjectTemplate::New(isolate, *constructor));
+}
+
+void v8cxx__object_template_new_instance(
+    v8::MaybeLocal<v8::Object>* local_buf,
+    v8::ObjectTemplate* object_template,
+    const v8::Local<v8::Context>* context) {
+  new (local_buf)
+      v8::MaybeLocal<v8::Object>(object_template->NewInstance(*context));
+}
+
+void v8cxx__object_template_set_named_property_handler(
+    v8::ObjectTemplate* object_template,
+    v8::NamedPropertyGetterCallback getter,
+    v8::NamedPropertySetterCallback setter,
+    v8::NamedPropertyQueryCallback query,
+    v8::NamedPropertyDeleterCallback deleter,
+    v8::NamedPropertyEnumeratorCallback enumerator,
+    v8::NamedPropertyDefinerCallback definer,
+    v8::NamedPropertyDescriptorCallback descriptor,
+    const v8::Local<v8::Value>* data,
+    v8::PropertyHandlerFlags flags) {
+  object_template->SetHandler(v8::NamedPropertyHandlerConfiguration(
+      getter, setter, query, deleter, enumerator, definer, descriptor, *data, flags));
+}
+
+void v8cxx__object_template_set_indexed_property_handler(
+    v8::ObjectTemplate* object_template,
+    v8::IndexedPropertyGetterCallbackV2 getter,
+    v8::IndexedPropertySetterCallbackV2 setter,
+    v8::IndexedPropertyQueryCallbackV2 query,
+    v8::IndexedPropertyDeleterCallbackV2 deleter,
+    v8::IndexedPropertyEnumeratorCallback enumerator,
+    v8::IndexedPropertyDefinerCallbackV2 definer,
+    v8::IndexedPropertyDescriptorCallbackV2 descriptor,
+    const v8::Local<v8::Value>* data,
+    v8::PropertyHandlerFlags flags) {
+  object_template->SetHandler(v8::IndexedPropertyHandlerConfiguration(
+      getter, setter, query, deleter, enumerator, definer, descriptor, *data, flags));
+}
+
+void v8cxx__object_template_set_call_as_function_handler(
+    v8::ObjectTemplate* object_template,
+    v8::FunctionCallback callback,
+    const v8::Local<v8::Value>* data) {
+  object_template->SetCallAsFunctionHandler(callback, *data);
+}
+
+void v8cxx__object_template_mark_as_undetectable(
+    v8::ObjectTemplate* object_template) {
+  object_template->MarkAsUndetectable();
+}
+
+// TODO: v8::ObjectTemplate::{
+//   SetAccessCheckCallback,
+//   SetAccessCheckCallbackAndHandler
+// }
+
+int v8cxx__object_template_internal_field_count(
+    const v8::ObjectTemplate* object_template) {
+  return object_template->InternalFieldCount();
+}
+
+void v8cxx__object_template_set_internal_field_count(
+    v8::ObjectTemplate* object_template,
+    int count) {
+  object_template->SetInternalFieldCount(count);
+}
+
+bool v8cxx__object_template_is_immutable_proto(
+    const v8::ObjectTemplate* object_template) {
+  return object_template->IsImmutableProto();
+}
+
+// TODO: v8::ObjectTemplate::{SetCodeLike, IsCodeLike}
+}
+
+// v8::PropertyCallbackInfo<T>
+extern "C" {
+v8::Isolate* v8cxx__property_callback_info_get_isolate(
+    const v8::PropertyCallbackInfo<v8::Value>* pci) {
+  return pci->GetIsolate();
+}
+
+void v8cxx__property_callback_info_data(
+    v8::Local<v8::Value>* local_buf,
+    const v8::PropertyCallbackInfo<v8::Value>* pci) {
+  new (local_buf) v8::Local<v8::Value>(pci->Data());
+}
+
+void v8cxx__property_callback_info_this(
+    v8::Local<v8::Object>* local_buf,
+    const v8::PropertyCallbackInfo<v8::Value>* pci) {
+  new (local_buf) v8::Local<v8::Object>(pci->This());
+}
+
+void v8cxx__property_callback_info_holder(
+    v8::Local<v8::Object>* local_buf,
+    const v8::PropertyCallbackInfo<v8::Value>* pci) {
+  new (local_buf) v8::Local<v8::Object>(pci->HolderV2());
+}
+
+void v8cxx__property_callback_info_get_return_value(
+    v8::ReturnValue<v8::Value>* buf,
+    const v8::PropertyCallbackInfo<v8::Value>* pci) {
+  new (buf) v8::ReturnValue<v8::Value>(pci->GetReturnValue());
+}
+
+bool v8cxx__property_callback_info_should_throw_on_error(
+    const v8::PropertyCallbackInfo<v8::Value>* pci) {
+  return pci->ShouldThrowOnError();
+}
+}
+
+// v8::Number
+extern "C" {
+void v8cxx__number_new(v8::Local<v8::Number>* local_buf,
+                       v8::Isolate* isolate,
+                       double value) {
+  new (local_buf) v8::Local<v8::Number>(v8::Number::New(isolate, value));
+}
+
+double v8cxx__number_value(const v8::Number* number) {
+  return number->Value();
+}
+}
+
+// v8::Integer
+extern "C" {
+void v8cxx__integer_new(v8::Local<v8::Integer>* local_buf,
+                        v8::Isolate* isolate,
+                        int32_t value) {
+  new (local_buf) v8::Local<v8::Integer>(v8::Integer::New(isolate, value));
+}
+
+void v8cxx__integer_new_from_unsigned(v8::Local<v8::Integer>* local_buf,
+                                      v8::Isolate* isolate,
+                                      uint32_t value) {
+  new (local_buf)
+      v8::Local<v8::Integer>(v8::Integer::NewFromUnsigned(isolate, value));
+}
+
+int64_t v8cxx__integer_value(const v8::Integer* integer) {
+  return integer->Value();
+}
+}
+
+// v8::Array
+extern "C" {
+uint32_t v8cxx__array_length(const v8::Array* array) {
+  return array->Length();
+}
+
+void v8cxx__array_new(v8::Local<v8::Array>* local_buf,
+                      v8::Isolate* isolate,
+                      int length) {
+  new (local_buf) v8::Local<v8::Array>(v8::Array::New(isolate, length));
+}
+
+void v8cxx__array_new_with_elements(v8::Local<v8::Array>* local_buf,
+                                    v8::Isolate* isolate,
+                                    const v8::Local<v8::Value>* elements,
+                                    size_t length) {
+  new (local_buf) v8::Local<v8::Array>(v8::Array::New(
+      isolate, const_cast<v8::Local<v8::Value>*>(elements), length));
+}
 }

--- a/v8/src/cpp/v8.cc
+++ b/v8/src/cpp/v8.cc
@@ -1012,3 +1012,54 @@ void v8cxx__(v8::Local<v8::Private>* local_buf,
   new (local_buf) v8::Local<v8::Private>(v8::Private::ForApi(isolate, *name));
 }
 }
+
+// v8::Signature
+extern "C" {
+void v8cxx__signature_new(v8::Local<v8::Signature>* local_buf,
+                          v8::Isolate* isolate,
+                          const v8::Local<v8::FunctionTemplate>* receiver) {
+  new (local_buf)
+      v8::Local<v8::Signature>(v8::Signature::New(isolate, *receiver));
+}
+}
+
+// v8::Template
+extern "C" {
+void v8cxx__template_set(v8::Template* template_,
+                         const v8::Local<v8::Name>* name,
+                         const v8::Local<v8::Data>* value,
+                         v8::PropertyAttribute attributes) {
+  template_->Set(*name, *value, attributes);
+}
+
+void v8cxx__template_set_private(v8::Template* template_,
+                                 const v8::Local<v8::Name>* name,
+                                 const v8::Local<v8::Data>* value,
+                                 v8::PropertyAttribute attributes) {
+  template_->SetPrivate(*name, *value, attributes);
+}
+
+void v8cxx__template_set_with_isolate(v8::Template* template_,
+                                  v8::Isolate* isolate,
+                                  const char* name,
+                                  const v8::Local<v8::Data>* value,
+                                  v8::PropertyAttribute attributes) {
+  template_->Set(isolate, name, *value, attributes);
+}
+
+void v8cxx__template_set_accessor_property(
+    v8::Template* template_,
+    const v8::Local<v8::Name>* name,
+    const v8::Local<v8::FunctionTemplate>* getter,
+    const v8::Local<v8::FunctionTemplate>* setter,
+    v8::PropertyAttribute attribute) {
+  template_->SetAccessorProperty(*name, *getter, *setter, attribute);
+}
+}
+
+// v8::FunctionTemplate 
+extern "C" {
+  void v8cxx__function_template_new(v8::FunctionTemplate* fn_template) {
+
+  }
+}

--- a/v8/src/cpp/v8.hpp
+++ b/v8/src/cpp/v8.hpp
@@ -3,5 +3,11 @@
 static uint32_t v8cxx__major_version = V8_MAJOR_VERSION;
 static uint32_t v8cxx__minor_version = V8_MINOR_VERSION;
 static uint32_t v8cxx__patch_level = V8_PATCH_LEVEL;
-static size_t v8cxx__sizeof_isolate__createparams = sizeof(v8::Isolate::CreateParams);
+static size_t v8cxx__sizeof_isolate__createparams =
+    sizeof(v8::Isolate::CreateParams);
 static size_t v8cxx__sizeof_handlescope = sizeof(v8::HandleScope);
+static size_t v8cxx__sizeof_scriptorigin = sizeof(v8::ScriptOrigin);
+static size_t v8cxx__sizeof_functioncallbackinfo =
+    sizeof(v8::FunctionCallbackInfo<void>);
+static size_t v8cxx__sizeof_propertycallbackinfo =
+    sizeof(v8::PropertyCallbackInfo<void>);

--- a/v8/src/function.rs
+++ b/v8/src/function.rs
@@ -1,0 +1,229 @@
+use std::mem::MaybeUninit;
+
+use crate::{
+    c_support::ClosureToFunction,
+    context::Context,
+    data::traits::Data,
+    function_callback_info::FunctionCallbackInfo,
+    function_template::{ConstructorBehavior, SideEffectType},
+    local::{Local, MaybeLocal},
+    object::{self, traits::Object},
+    script_origin::ScriptOrigin,
+    string::String,
+    value::{self, traits::Value},
+};
+
+extern "C" {
+    fn v8cxx__function_new(
+        maybe_local_buf: *mut MaybeLocal<Function>,
+        context: *const Local<Context>,
+        callback: ExternFunctionCallback,
+        data: *const Local<value::Value>,
+        length: i32,
+        behavior: ConstructorBehavior,
+        side_effect_type: SideEffectType,
+    );
+    fn v8cxx__function_new_instance(
+        maybe_local_buf: *mut MaybeLocal<object::Object>,
+        this: *const Function,
+        context: *const Local<Context>,
+        argc: i32,
+        argv: *mut Local<value::Value>,
+    );
+    fn v8cxx__function_new_instance_with_side_effect_type(
+        maybe_local_buf: *mut MaybeLocal<object::Object>,
+        this: *const Function,
+        context: *const Local<Context>,
+        argc: i32,
+        argv: *mut Local<value::Value>,
+        side_effect_type: SideEffectType,
+    );
+    fn v8cxx__function_set_name(this: *mut Function, name: *const Local<String>);
+    fn v8cxx__function_get_name(local_buf: *mut Local<value::Value>, this: *const Function);
+    fn v8cxx__function_get_inferred_name(
+        local_buf: *mut Local<value::Value>,
+        this: *const Function,
+    );
+    fn v8cxx__function_get_script_line_number(this: *const Function) -> i32;
+    fn v8cxx__function_get_script_column_number(this: *const Function) -> i32;
+    fn v8cxx__function_script_id(this: *const Function) -> i32;
+    fn v8cxx__function_get_bound_function(
+        local_buf: *mut Local<value::Value>,
+        this: *const Function,
+    );
+    fn v8cxx__function_function_proto_to_string(
+        maybe_local_buf: *mut MaybeLocal<String>,
+        this: *mut Function,
+        context: *const Local<Context>,
+    );
+    fn v8cxx__function_get_script_origin(buf: *mut ScriptOrigin, this: *const Function);
+}
+
+#[repr(C)]
+pub struct Function([u8; 0]);
+
+impl Function {
+    #[inline(always)]
+    pub fn new<F>(
+        context: &Local<Context>,
+        callback: F,
+        data: &Local<value::Value>,
+        length: i32,
+        behavior: ConstructorBehavior,
+        side_effect_type: SideEffectType,
+    ) -> MaybeLocal<Function>
+    where
+        F: Fn(&FunctionCallbackInfo<value::Value>),
+    {
+        let mut maybe_local_function = MaybeLocal::empty();
+
+        unsafe {
+            v8cxx__function_new(
+                &mut maybe_local_function,
+                context,
+                callback.to_function(),
+                data,
+                length,
+                behavior,
+                side_effect_type,
+            )
+        };
+
+        maybe_local_function
+    }
+
+    #[inline(always)]
+    pub fn new_instance(
+        &self,
+        context: &Local<Context>,
+        args: &mut Vec<Local<value::Value>>,
+    ) -> MaybeLocal<object::Object> {
+        let mut maybe_local_object = MaybeLocal::empty();
+
+        unsafe {
+            v8cxx__function_new_instance(
+                &mut maybe_local_object,
+                self,
+                context,
+                args.len() as i32,
+                args.as_mut_ptr(),
+            )
+        };
+
+        maybe_local_object
+    }
+
+    #[inline(always)]
+    pub fn new_instance_with_side_effect_type(
+        &self,
+        context: &Local<Context>,
+        args: &mut Vec<Local<value::Value>>,
+        side_effect_type: SideEffectType,
+    ) -> MaybeLocal<object::Object> {
+        let mut maybe_local_object = MaybeLocal::empty();
+
+        unsafe {
+            v8cxx__function_new_instance_with_side_effect_type(
+                &mut maybe_local_object,
+                self,
+                context,
+                args.len() as i32,
+                args.as_mut_ptr(),
+                side_effect_type,
+            )
+        };
+
+        maybe_local_object
+    }
+
+    #[inline(always)]
+    pub fn set_name(&mut self, name: &Local<String>) {
+        unsafe { v8cxx__function_set_name(self, name) };
+    }
+
+    #[inline(always)]
+    pub fn get_name(&self) -> Local<value::Value> {
+        let mut local_value = Local::empty();
+
+        unsafe { v8cxx__function_get_name(&mut local_value, self) };
+
+        local_value
+    }
+
+    #[inline(always)]
+    pub fn get_inferred_name(&self) -> Local<value::Value> {
+        let mut local_value = Local::empty();
+
+        unsafe {
+            v8cxx__function_get_inferred_name(&mut local_value, self);
+        }
+
+        local_value
+    }
+
+    #[inline(always)]
+    pub fn get_script_line_number(&self) -> i32 {
+        unsafe { v8cxx__function_get_script_line_number(self) }
+    }
+
+    #[inline(always)]
+    pub fn get_script_column_number(&self) -> i32 {
+        unsafe { v8cxx__function_get_script_column_number(self) }
+    }
+
+    #[inline(always)]
+    pub fn script_id(&self) -> i32 {
+        unsafe { v8cxx__function_script_id(self) }
+    }
+
+    #[inline(always)]
+    pub fn get_bound_function(&self) -> Local<value::Value> {
+        let mut local_value = Local::empty();
+
+        unsafe { v8cxx__function_get_bound_function(&mut local_value, self) };
+
+        local_value
+    }
+
+    #[inline(always)]
+    pub fn function_proto_to_string(&mut self, context: &Local<Context>) -> MaybeLocal<String> {
+        let mut maybe_local_string = MaybeLocal::empty();
+
+        unsafe { v8cxx__function_function_proto_to_string(&mut maybe_local_string, self, context) };
+
+        maybe_local_string
+    }
+
+    #[inline(always)]
+    pub fn get_script_origin(&self) -> ScriptOrigin {
+        unsafe {
+            let mut script_origin = MaybeUninit::<ScriptOrigin>::zeroed();
+
+            v8cxx__function_get_script_origin(script_origin.as_mut_ptr(), self);
+
+            script_origin.assume_init()
+        }
+    }
+}
+
+impl Data for Function {}
+impl Value for Function {}
+impl Object for Function {}
+
+pub type ExternFunctionCallback = extern "C" fn(info: *const FunctionCallbackInfo<value::Value>);
+
+impl<T> ClosureToFunction<ExternFunctionCallback> for T
+where
+    T: Fn(&FunctionCallbackInfo<value::Value>),
+{
+    fn to_function(self) -> ExternFunctionCallback {
+        extern "C" fn function<T>(info: *const FunctionCallbackInfo<value::Value>)
+        where
+            T: Fn(&FunctionCallbackInfo<value::Value>),
+        {
+            T::get()(unsafe { info.as_ref().unwrap() });
+        }
+
+        function::<T>
+    }
+}

--- a/v8/src/function_callback_info.rs
+++ b/v8/src/function_callback_info.rs
@@ -1,0 +1,130 @@
+use std::{marker::PhantomData, mem::{transmute, MaybeUninit}};
+
+use crate::{
+    bindings,
+    isolate::Isolate,
+    local::Local,
+    object::Object,
+    return_value::ReturnValue,
+    value::{self, traits::Value},
+};
+
+extern "C" {
+    fn v8cxx__function_callback_info_length(this: *const FunctionCallbackInfo<value::Value>)
+        -> i32;
+    fn v8cxx__function_callback_info_at(
+        local_buf: *mut Local<value::Value>,
+        this: *const FunctionCallbackInfo<value::Value>,
+        index: i32,
+    );
+    fn v8cxx__function_callback_info_this(
+        local_buf: *mut Local<Object>,
+        this: *const FunctionCallbackInfo<value::Value>,
+    );
+    fn v8cxx__function_callback_info_new_target(
+        local_buf: *mut Local<value::Value>,
+        this: *const FunctionCallbackInfo<value::Value>,
+    );
+    fn v8cxx__function_callback_info_is_construct_call(
+        this: *const FunctionCallbackInfo<value::Value>,
+    ) -> bool;
+    fn v8cxx__function_callback_info_data(
+        local_buf: *mut Local<value::Value>,
+        this: *const FunctionCallbackInfo<value::Value>,
+    );
+    fn v8cxx__function_callback_info_get_isolate(
+        this: *const FunctionCallbackInfo<value::Value>,
+    ) -> *mut Isolate;
+    fn v8cxx__function_callback_info_get_return_value(
+        buf: *mut ReturnValue<value::Value>,
+        this: *const FunctionCallbackInfo<value::Value>,
+    );
+}
+
+#[repr(C)]
+pub struct FunctionCallbackInfo<T: Value>(
+    [u8; bindings::v8cxx__sizeof_functioncallbackinfo],
+    PhantomData<T>,
+);
+
+impl<T: Value> FunctionCallbackInfo<T> {
+    #[inline(always)]
+    pub fn cast<U: Value>(self) -> FunctionCallbackInfo<U> {
+        FunctionCallbackInfo(self.0, PhantomData)
+    }
+
+    #[inline(always)]
+    pub fn cast_ref<U: Value>(&self) -> &FunctionCallbackInfo<U> {
+        unsafe { transmute(self) }
+    }
+
+    #[inline(always)]
+    pub fn cast_mut<U: Value>(&mut self) -> &mut FunctionCallbackInfo<U> {
+        unsafe { transmute(self) }
+    }
+
+    #[inline(always)]
+    pub fn length(&self) -> i32 {
+        unsafe { v8cxx__function_callback_info_length(self.cast_ref()) }
+    }
+
+    #[inline(always)]
+    pub fn at(&self, index: i32) -> Local<value::Value> {
+        let mut local_value = Local::empty();
+
+        unsafe { v8cxx__function_callback_info_at(&mut local_value, self.cast_ref(), index) };
+
+        local_value
+    }
+
+    #[inline(always)]
+    pub fn this(&self) -> Local<Object> {
+        let mut local_object = Local::empty();
+
+        unsafe { v8cxx__function_callback_info_this(&mut local_object, self.cast_ref()) };
+
+        local_object
+    }
+
+    #[inline(always)]
+    pub fn new_target(&self) -> Local<value::Value> {
+        let mut local_value = Local::empty();
+
+        unsafe { v8cxx__function_callback_info_new_target(&mut local_value, self.cast_ref()) };
+
+        local_value
+    }
+
+    #[inline(always)]
+    pub fn is_construct_call(&self) -> bool {
+        unsafe { v8cxx__function_callback_info_is_construct_call(self.cast_ref()) }
+    }
+
+    #[inline(always)]
+    pub fn data(&self) -> Local<value::Value> {
+        let mut local_value = Local::empty();
+
+        unsafe { v8cxx__function_callback_info_data(&mut local_value, self.cast_ref()) };
+
+        local_value
+    }
+
+    #[inline(always)]
+    pub fn get_isolate(&self) -> Option<&mut Isolate> {
+        unsafe { v8cxx__function_callback_info_get_isolate(self.cast_ref()).as_mut() }
+    }
+
+    #[inline(always)]
+    pub fn get_return_value(&self) -> ReturnValue<value::Value> {
+        unsafe {
+            let mut return_value = MaybeUninit::zeroed();
+
+            v8cxx__function_callback_info_get_return_value(
+                return_value.as_mut_ptr(),
+                self.cast_ref(),
+            );
+
+            return_value.assume_init()
+        }
+    }
+}

--- a/v8/src/function_template.rs
+++ b/v8/src/function_template.rs
@@ -1,0 +1,194 @@
+use crate::{
+    c_support::ClosureToFunction,
+    context::Context,
+    data::traits::Data,
+    function::{ExternFunctionCallback, Function},
+    function_callback_info::FunctionCallbackInfo,
+    isolate::Isolate,
+    local::{Local, MaybeLocal},
+    object_template::ObjectTemplate,
+    signature::Signature,
+    string::String,
+    template::traits::Template,
+    value::Value,
+};
+
+extern "C" {
+    fn v8cxx__function_template_new(
+        local_buf: *mut Local<FunctionTemplate>,
+        isolate: *mut Isolate,
+        fn_callback: ExternFunctionCallback,
+        data: *const Local<Value>,
+        signature: *const Local<Signature>,
+        length: i32,
+        behavior: ConstructorBehavior,
+        side_effect_type: SideEffectType,
+    );
+    fn v8cxx__function_template_get_function(
+        maybe_local_buf: *mut MaybeLocal<Function>,
+        this: *mut FunctionTemplate,
+        context: *const Local<Context>,
+    );
+    fn v8cxx__function_template_instance_template(
+        local_buf: *mut Local<ObjectTemplate>,
+        this: *mut FunctionTemplate,
+    );
+    fn v8cxx__function_template_inherit(
+        this: *mut FunctionTemplate,
+        parent: *const Local<FunctionTemplate>,
+    );
+    fn v8cxx__function_template_prototype_template(
+        local_buf: *mut Local<ObjectTemplate>,
+        this: *mut FunctionTemplate,
+    );
+    fn v8cxx__function_template_set_prototype_provider_template(
+        this: *mut FunctionTemplate,
+        prototype_provider: *const Local<FunctionTemplate>,
+    );
+    fn v8cxx__function_template_set_class_name(
+        this: *mut FunctionTemplate,
+        name: *const Local<String>,
+    );
+    fn v8cxx__function_template_set_interface_name(
+        this: *mut FunctionTemplate,
+        name: *const Local<String>,
+    );
+    fn v8cxx__function_template_read_only_prototype(this: *mut FunctionTemplate);
+    fn v8cxx__function_template_remove_prototype(this: *mut FunctionTemplate);
+    fn v8cxx__function_template_has_instance(
+        this: *mut FunctionTemplate,
+        object: *const Local<Value>,
+    ) -> bool;
+}
+
+#[repr(C)]
+pub struct FunctionTemplate([u8; 0]);
+
+impl FunctionTemplate {
+    #[inline(always)]
+    pub fn new<F>(
+        isolate: &mut Isolate,
+        callback: F,
+        data: &Local<Value>,
+        signature: &Local<Signature>,
+        length: i32,
+        behavior: ConstructorBehavior,
+        side_effect_type: SideEffectType,
+    ) -> Local<Self>
+    where
+        F: Fn(&FunctionCallbackInfo<Value>),
+    {
+        let mut local_function_template = Local::empty();
+
+        unsafe {
+            v8cxx__function_template_new(
+                &mut local_function_template,
+                isolate,
+                callback.to_function(),
+                data,
+                signature,
+                length,
+                behavior,
+                side_effect_type,
+            )
+        };
+
+        local_function_template
+    }
+
+    #[inline(always)]
+    pub fn new_default<F>(isolate: &mut Isolate, callback: F) -> Local<Self>
+    where
+        F: Fn(&FunctionCallbackInfo<Value>),
+    {
+        Self::new(
+            isolate,
+            callback,
+            &Local::empty(),
+            &Local::empty(),
+            0,
+            ConstructorBehavior::Allow,
+            SideEffectType::HasSideEffect,
+        )
+    }
+
+    #[inline(always)]
+    pub fn get_function(&mut self, context: &Local<Context>) -> MaybeLocal<Function> {
+        let mut maybe_local_function = MaybeLocal::empty();
+
+        unsafe { v8cxx__function_template_get_function(&mut maybe_local_function, self, context) };
+
+        maybe_local_function
+    }
+
+    #[inline(always)]
+    pub fn instance_template(&mut self) -> Local<ObjectTemplate> {
+        let mut local_object_template = Local::empty();
+
+        unsafe { v8cxx__function_template_instance_template(&mut local_object_template, self) };
+
+        local_object_template
+    }
+
+    #[inline(always)]
+    pub fn inherit(&mut self, parent: &Local<Self>) {
+        unsafe { v8cxx__function_template_inherit(self, parent) };
+    }
+
+    #[inline(always)]
+    pub fn prototype_template(&mut self) -> Local<ObjectTemplate> {
+        let mut local_object_template = Local::empty();
+
+        unsafe { v8cxx__function_template_prototype_template(&mut local_object_template, self) };
+
+        local_object_template
+    }
+
+    #[inline(always)]
+    pub fn set_prototype_provider_template(&mut self, prototype_provider: &Local<Self>) {
+        unsafe {
+            v8cxx__function_template_set_prototype_provider_template(self, prototype_provider)
+        };
+    }
+
+    #[inline(always)]
+    pub fn set_class_name(&mut self, name: &Local<String>) {
+        unsafe { v8cxx__function_template_set_class_name(self, name) };
+    }
+
+    #[inline(always)]
+    pub fn set_interface_name(&mut self, name: &Local<String>) {
+        unsafe { v8cxx__function_template_set_interface_name(self, name) };
+    }
+
+    #[inline(always)]
+    pub fn read_only_prototype(&mut self) {
+        unsafe { v8cxx__function_template_read_only_prototype(self) };
+    }
+
+    #[inline(always)]
+    pub fn remove_prototype(&mut self) {
+        unsafe { v8cxx__function_template_remove_prototype(self) };
+    }
+
+    #[inline(always)]
+    pub fn has_instance(&mut self, object: &Local<Value>) -> bool {
+        unsafe { v8cxx__function_template_has_instance(self, object) }
+    }
+}
+
+impl Data for FunctionTemplate {}
+impl Template for FunctionTemplate {}
+
+#[repr(C)]
+pub enum ConstructorBehavior {
+    Throw,
+    Allow,
+}
+
+#[repr(C)]
+pub enum SideEffectType {
+    HasSideEffect,
+    HasNoSideEffect,
+    HasSideEffectToReceiver,
+}

--- a/v8/src/integer.rs
+++ b/v8/src/integer.rs
@@ -1,0 +1,55 @@
+use crate::{
+    data::traits::Data, isolate::Isolate, local::Local, number::traits::Number,
+    numeric::traits::Numeric, primitive::traits::Primitive, value::traits::Value,
+};
+
+extern "C" {
+    fn v8cxx__integer_new(local_buf: *mut Local<Integer>, isolate: *mut Isolate, value: i32);
+    fn v8cxx__integer_new_from_unsigned(
+        local_buf: *mut Local<Integer>,
+        isolate: *mut Isolate,
+        value: u32,
+    );
+    fn v8cxx__integer_value(this: *const Integer) -> i64;
+}
+
+#[repr(C)]
+pub struct Integer([u8; 0]);
+
+impl Integer {
+    #[inline(always)]
+    pub fn new(isolate: &mut Isolate, value: i32) -> Local<Self> {
+        let mut local_integer = Local::empty();
+
+        unsafe { v8cxx__integer_new(&mut local_integer, isolate, value) };
+
+        local_integer
+    }
+
+    #[inline(always)]
+    pub fn new_from_unsigned(isolate: &mut Isolate, value: u32) -> Local<Self> {
+        let mut local_integer = Local::empty();
+
+        unsafe { v8cxx__integer_new_from_unsigned(&mut local_integer, isolate, value) };
+
+        local_integer
+    }
+}
+
+impl Data for Integer {}
+impl Value for Integer {}
+impl Primitive for Integer {}
+impl Numeric for Integer {}
+impl Number for Integer {}
+
+pub mod traits {
+    use crate::number::traits::Number;
+
+    use super::*;
+
+    pub trait Integer: Number {
+        fn value(&self) -> i64 {
+            unsafe { v8cxx__integer_value(self as *const _ as *const _) }
+        }
+    }
+}

--- a/v8/src/lib.rs
+++ b/v8/src/lib.rs
@@ -5,12 +5,17 @@ mod bindings {
     include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 }
 
+pub mod array;
 pub mod array_buffer;
 pub mod bigint;
 pub mod boolean;
 pub mod context;
 pub mod data;
 pub mod fixed_array;
+pub mod function;
+pub mod function_callback_info;
+pub mod function_template;
+pub mod integer;
 pub mod isolate;
 pub mod local;
 pub mod microtask_queue;
@@ -25,8 +30,11 @@ pub mod platform;
 pub mod primitive;
 pub mod primitive_array;
 pub mod private;
+pub mod property_callback_info;
+pub mod return_value;
 pub mod scope;
 pub mod script;
+pub mod script_origin;
 pub mod signature;
 pub mod string;
 pub mod symbol;

--- a/v8/src/lib.rs
+++ b/v8/src/lib.rs
@@ -27,8 +27,10 @@ pub mod primitive_array;
 pub mod private;
 pub mod scope;
 pub mod script;
+pub mod signature;
 pub mod string;
 pub mod symbol;
+pub mod template;
 pub mod v8;
 pub mod value;
 

--- a/v8/src/number.rs
+++ b/v8/src/number.rs
@@ -1,12 +1,40 @@
 use crate::{
-    data::traits::Data, numeric::traits::Numeric, primitive::traits::Primitive,
-    value::traits::Value,
+    data::traits::Data, isolate::Isolate, local::Local, numeric::traits::Numeric,
+    primitive::traits::Primitive, value::traits::Value,
 };
+
+extern "C" {
+    fn v8cxx__number_new(local_buf: *mut Local<Number>, isolate: *mut Isolate, value: f64);
+    fn v8cxx__number_value(this: *const Number) -> f64;
+}
 
 #[repr(C)]
 pub struct Number([u8; 0]);
+
+impl Number {
+    #[inline(always)]
+    pub fn new(isolate: &mut Isolate, value: f64) -> Local<Self> {
+        let mut local_value = Local::empty();
+
+        unsafe { v8cxx__number_new(&mut local_value, isolate, value) };
+
+        local_value
+    }
+}
 
 impl Data for Number {}
 impl Value for Number {}
 impl Primitive for Number {}
 impl Numeric for Number {}
+
+pub mod traits {
+    use crate::numeric::traits::Numeric;
+
+    use super::v8cxx__number_value;
+
+    pub trait Number: Numeric {
+        fn value(&self) -> f64 {
+            unsafe { v8cxx__number_value(self as *const _ as *const _) }
+        }
+    }
+}

--- a/v8/src/object_template.rs
+++ b/v8/src/object_template.rs
@@ -1,6 +1,463 @@
-use crate::data::traits::Data;
+use crate::{
+    array::Array,
+    boolean::Boolean,
+    c_support::ClosureToFunction,
+    context::Context,
+    data::traits::Data,
+    function::ExternFunctionCallback,
+    function_callback_info::FunctionCallbackInfo,
+    function_template::FunctionTemplate,
+    integer::Integer,
+    isolate::Isolate,
+    local::{Local, MaybeLocal},
+    name::Name,
+    object::Object,
+    property_callback_info::PropertyCallbackInfo,
+    template::traits::Template,
+    value::Value,
+};
+
+extern "C" {
+    fn v8cxx_object_template_new(
+        local_buf: *mut Local<ObjectTemplate>,
+        isolate: *mut Isolate,
+        constructor: *const Local<FunctionTemplate>,
+    );
+    fn v8cxx_object_template_new_instance(
+        local_buf: *mut MaybeLocal<Object>,
+        object_template: *mut ObjectTemplate,
+        context: *const Local<Context>,
+    );
+    fn v8cxx_object_template_set_named_property_handler(
+        object_template: *mut ObjectTemplate,
+        getter: Option<ExternNamedPropertyGetterCallback>,
+        setter: Option<ExternNamedPropertySetterCallback>,
+        query: Option<ExternNamedPropertyQueryCallback>,
+        deleter: Option<ExternNamedPropertyDeleterCallback>,
+        enumerator: Option<ExternNamedPropertyEnumeratorCallback>,
+        definer: Option<ExternNamedPropertyDefinerCallback>,
+        descriptor: Option<ExternNamedPropertyDescriptorCallback>,
+        data: *const Local<Value>,
+        flags: PropertyHandlerFlags,
+    );
+    fn v8cxx_object_template_set_indexed_property_handler(
+        object_template: *mut ObjectTemplate,
+        getter: Option<ExternIndexedPropertyGetterCallbackV2>,
+        setter: Option<ExternIndexedPropertySetterCallbackV2>,
+        query: Option<ExternIndexedPropertyQueryCallbackV2>,
+        deleter: Option<ExternIndexedPropertyDeleterCallbackV2>,
+        enumerator: Option<ExternIndexedPropertyEnumeratorCallback>,
+        definer: Option<ExternIndexedPropertyDefinerCallbackV2>,
+        descriptor: Option<ExternIndexedPropertyDescriptorCallbackV2>,
+        data: *const Local<Value>,
+        flags: PropertyHandlerFlags,
+    );
+    fn v8cxx_object_template_set_call_as_function_handler(
+        object_template: *mut ObjectTemplate,
+        callback: ExternFunctionCallback,
+        data: *const Local<Value>,
+    );
+    fn v8cxx_object_template_mark_as_undetectable(object_template: *mut ObjectTemplate);
+    fn v8cxx_object_template_internal_field_count(object_template: *const ObjectTemplate) -> i32;
+    fn v8cxx_object_template_set_internal_field_count(
+        object_template: *mut ObjectTemplate,
+        count: i32,
+    );
+    fn v8cxx_object_template_is_immutable_proto(object_template: *const ObjectTemplate) -> bool;
+}
 
 #[repr(C)]
 pub struct ObjectTemplate([u8; 0]);
 
+impl ObjectTemplate {
+    #[inline(always)]
+    pub fn new(isolate: &mut Isolate, constructor: &Local<FunctionTemplate>) -> Local<Self> {
+        let mut local_object_template = Local::empty();
+
+        unsafe { v8cxx_object_template_new(&mut local_object_template, isolate, constructor) };
+
+        local_object_template
+    }
+
+    #[inline(always)]
+    pub fn new_instance(&mut self, context: &Local<Context>) -> MaybeLocal<Object> {
+        let mut maybe_local_object = MaybeLocal::empty();
+
+        unsafe { v8cxx_object_template_new_instance(&mut maybe_local_object, self, context) };
+
+        maybe_local_object
+    }
+
+    #[inline(always)]
+    pub fn set_named_property_handler(
+        &mut self,
+        getter: Option<impl Fn(Local<Name>, &PropertyCallbackInfo<Value>) -> Intercepted>,
+        setter: Option<
+            impl Fn(Local<Name>, Local<Value>, &PropertyCallbackInfo<()>) -> Intercepted,
+        >,
+        query: Option<impl Fn(Local<Name>, &PropertyCallbackInfo<Integer>) -> Intercepted>,
+        deleter: Option<impl Fn(Local<Name>, &PropertyCallbackInfo<Boolean>) -> Intercepted>,
+        enumerator: Option<impl Fn(&PropertyCallbackInfo<Array>)>,
+        definer: Option<
+            impl Fn(Local<Name>, &PropertyDescriptor, &PropertyCallbackInfo<()>) -> Intercepted,
+        >,
+        descriptor: Option<impl Fn(Local<Name>, &PropertyCallbackInfo<Value>) -> Intercepted>,
+        data: &Local<Value>,
+        flags: PropertyHandlerFlags,
+    ) {
+        unsafe {
+            v8cxx_object_template_set_named_property_handler(
+                self,
+                getter.map(|f| f.to_function()),
+                setter.map(|f| f.to_function()),
+                query.map(|f| f.to_function()),
+                deleter.map(|f| f.to_function()),
+                enumerator.map(|f| f.to_function()),
+                definer.map(|f| f.to_function()),
+                descriptor.map(|f| f.to_function()),
+                data,
+                flags,
+            )
+        };
+    }
+
+    #[inline(always)]
+    pub fn set_indexed_property_handler(
+        &mut self,
+        getter: Option<impl Fn(u32, &PropertyCallbackInfo<Value>) -> Intercepted>,
+        setter: Option<impl Fn(u32, Local<Value>, &PropertyCallbackInfo<()>) -> Intercepted>,
+        query: Option<impl Fn(u32, &PropertyCallbackInfo<Integer>) -> Intercepted>,
+        deleter: Option<impl Fn(u32, &PropertyCallbackInfo<Boolean>) -> Intercepted>,
+        enumerator: Option<impl Fn(&PropertyCallbackInfo<Array>)>,
+        definer: Option<
+            impl Fn(u32, &PropertyDescriptor, &PropertyCallbackInfo<()>) -> Intercepted,
+        >,
+        descriptor: Option<impl Fn(u32, &PropertyCallbackInfo<Value>) -> Intercepted>,
+        data: &Local<Value>,
+        flags: PropertyHandlerFlags,
+    ) {
+        unsafe {
+            v8cxx_object_template_set_indexed_property_handler(
+                self,
+                getter.map(|f| f.to_function()),
+                setter.map(|f| f.to_function()),
+                query.map(|f| f.to_function()),
+                deleter.map(|f| f.to_function()),
+                enumerator.map(|f| f.to_function()),
+                definer.map(|f| f.to_function()),
+                descriptor.map(|f| f.to_function()),
+                data,
+                flags,
+            )
+        };
+    }
+
+    #[inline(always)]
+    pub fn set_call_as_function_handler<F>(&mut self, callback: F, data: &Local<Value>)
+    where
+        F: Fn(&FunctionCallbackInfo<Value>),
+    {
+        unsafe {
+            v8cxx_object_template_set_call_as_function_handler(self, callback.to_function(), data)
+        };
+    }
+
+    #[inline(always)]
+    pub fn mark_as_undetectable(&mut self) {
+        unsafe { v8cxx_object_template_mark_as_undetectable(self) };
+    }
+
+    #[inline(always)]
+    pub fn internal_field_count(&self) -> i32 {
+        unsafe { v8cxx_object_template_internal_field_count(self) }
+    }
+
+    #[inline(always)]
+    pub fn set_internal_field_count(&mut self, count: i32) {
+        unsafe { v8cxx_object_template_set_internal_field_count(self, count) };
+    }
+
+    #[inline(always)]
+    pub fn is_immutable_proto(&self) -> bool {
+        unsafe { v8cxx_object_template_is_immutable_proto(self) }
+    }
+}
+
 impl Data for ObjectTemplate {}
+impl Template for ObjectTemplate {}
+
+#[repr(u8)]
+pub enum Intercepted {
+    No,
+    Yes,
+}
+
+#[repr(C)]
+pub enum PropertyHandlerFlags {
+    None = 0,
+    NonMasking = 1,
+    OnlyInterceptStrings = 1 << 1,
+    HasNoSideEffect = 1 << 2,
+    InternalNewCallbacksSignatures = 1 << 10,
+}
+
+// TODO: implement this
+#[repr(C)]
+pub struct PropertyDescriptor([u8; 0]);
+
+type ExternNamedPropertyGetterCallback =
+    extern "C" fn(Local<Name>, *const PropertyCallbackInfo<Value>) -> Intercepted;
+
+type ExternNamedPropertySetterCallback =
+    extern "C" fn(Local<Name>, Local<Value>, *const PropertyCallbackInfo<()>) -> Intercepted;
+
+type ExternNamedPropertyQueryCallback =
+    extern "C" fn(Local<Name>, *const PropertyCallbackInfo<Integer>) -> Intercepted;
+
+type ExternNamedPropertyDeleterCallback =
+    extern "C" fn(Local<Name>, *const PropertyCallbackInfo<Boolean>) -> Intercepted;
+
+type ExternNamedPropertyEnumeratorCallback = extern "C" fn(*const PropertyCallbackInfo<Array>);
+
+type ExternNamedPropertyDefinerCallback = extern "C" fn(
+    Local<Name>,
+    *const PropertyDescriptor,
+    *const PropertyCallbackInfo<()>,
+) -> Intercepted;
+
+type ExternNamedPropertyDescriptorCallback =
+    extern "C" fn(Local<Name>, *const PropertyCallbackInfo<Value>) -> Intercepted;
+
+type ExternIndexedPropertyGetterCallbackV2 =
+    extern "C" fn(u32, *const PropertyCallbackInfo<Value>) -> Intercepted;
+
+type ExternIndexedPropertySetterCallbackV2 =
+    extern "C" fn(u32, Local<Value>, *const PropertyCallbackInfo<()>) -> Intercepted;
+
+type ExternIndexedPropertyQueryCallbackV2 =
+    extern "C" fn(u32, *const PropertyCallbackInfo<Integer>) -> Intercepted;
+
+type ExternIndexedPropertyDeleterCallbackV2 =
+    extern "C" fn(u32, *const PropertyCallbackInfo<Boolean>) -> Intercepted;
+
+type ExternIndexedPropertyEnumeratorCallback = extern "C" fn(*const PropertyCallbackInfo<Array>);
+
+type ExternIndexedPropertyDefinerCallbackV2 =
+    extern "C" fn(u32, *const PropertyDescriptor, *const PropertyCallbackInfo<()>) -> Intercepted;
+
+type ExternIndexedPropertyDescriptorCallbackV2 =
+    extern "C" fn(u32, *const PropertyCallbackInfo<Value>) -> Intercepted;
+
+impl<T> ClosureToFunction<ExternNamedPropertyGetterCallback> for T
+where
+    T: Fn(Local<Name>, &PropertyCallbackInfo<Value>) -> Intercepted,
+{
+    fn to_function(self) -> ExternNamedPropertyGetterCallback {
+        extern "C" fn function<T>(
+            property: Local<Name>,
+            pci: *const PropertyCallbackInfo<Value>,
+        ) -> Intercepted
+        where
+            T: Fn(Local<Name>, &PropertyCallbackInfo<Value>) -> Intercepted,
+        {
+            T::get()(property, unsafe { pci.as_ref().unwrap() })
+        }
+
+        function::<T>
+    }
+}
+
+impl<T> ClosureToFunction<ExternNamedPropertySetterCallback> for T
+where
+    T: Fn(Local<Name>, Local<Value>, &PropertyCallbackInfo<()>) -> Intercepted,
+{
+    fn to_function(self) -> ExternNamedPropertySetterCallback {
+        extern "C" fn function<T>(
+            property: Local<Name>,
+            value: Local<Value>,
+            pci: *const PropertyCallbackInfo<()>,
+        ) -> Intercepted
+        where
+            T: Fn(Local<Name>, Local<Value>, &PropertyCallbackInfo<()>) -> Intercepted,
+        {
+            T::get()(property, value, unsafe { pci.as_ref().unwrap() })
+        }
+
+        function::<T>
+    }
+}
+
+impl<T> ClosureToFunction<ExternNamedPropertyQueryCallback> for T
+where
+    T: Fn(Local<Name>, &PropertyCallbackInfo<Integer>) -> Intercepted,
+{
+    fn to_function(self) -> ExternNamedPropertyQueryCallback {
+        extern "C" fn function<T>(
+            property: Local<Name>,
+            pci: *const PropertyCallbackInfo<Integer>,
+        ) -> Intercepted
+        where
+            T: Fn(Local<Name>, &PropertyCallbackInfo<Integer>) -> Intercepted,
+        {
+            T::get()(property, unsafe { pci.as_ref().unwrap() })
+        }
+
+        function::<T>
+    }
+}
+
+impl<T> ClosureToFunction<ExternNamedPropertyDeleterCallback> for T
+where
+    T: Fn(Local<Name>, &PropertyCallbackInfo<Boolean>) -> Intercepted,
+{
+    fn to_function(self) -> ExternNamedPropertyDeleterCallback {
+        extern "C" fn function<T>(
+            property: Local<Name>,
+            pci: *const PropertyCallbackInfo<Boolean>,
+        ) -> Intercepted
+        where
+            T: Fn(Local<Name>, &PropertyCallbackInfo<Boolean>) -> Intercepted,
+        {
+            T::get()(property, unsafe { pci.as_ref().unwrap() })
+        }
+
+        function::<T>
+    }
+}
+
+impl<T> ClosureToFunction<ExternNamedPropertyEnumeratorCallback> for T
+where
+    T: Fn(&PropertyCallbackInfo<Array>),
+{
+    fn to_function(self) -> ExternNamedPropertyEnumeratorCallback {
+        extern "C" fn function<T>(pci: *const PropertyCallbackInfo<Array>)
+        where
+            T: Fn(&PropertyCallbackInfo<Array>),
+        {
+            T::get()(unsafe { pci.as_ref().unwrap() })
+        }
+
+        function::<T>
+    }
+}
+
+impl<T> ClosureToFunction<ExternNamedPropertyDefinerCallback> for T
+where
+    T: Fn(Local<Name>, &PropertyDescriptor, &PropertyCallbackInfo<()>) -> Intercepted,
+{
+    fn to_function(self) -> ExternNamedPropertyDefinerCallback {
+        extern "C" fn function<T>(
+            property: Local<Name>,
+            desc: *const PropertyDescriptor,
+            pci: *const PropertyCallbackInfo<()>,
+        ) -> Intercepted
+        where
+            T: Fn(Local<Name>, &PropertyDescriptor, &PropertyCallbackInfo<()>) -> Intercepted,
+        {
+            T::get()(property, unsafe { desc.as_ref().unwrap() }, unsafe {
+                pci.as_ref().unwrap()
+            })
+        }
+
+        function::<T>
+    }
+}
+
+impl<T> ClosureToFunction<ExternIndexedPropertyGetterCallbackV2> for T
+where
+    T: Fn(u32, &PropertyCallbackInfo<Value>) -> Intercepted,
+{
+    fn to_function(self) -> ExternIndexedPropertyGetterCallbackV2 {
+        extern "C" fn function<T>(
+            index: u32,
+            pci: *const PropertyCallbackInfo<Value>,
+        ) -> Intercepted
+        where
+            T: Fn(u32, &PropertyCallbackInfo<Value>) -> Intercepted,
+        {
+            T::get()(index, unsafe { pci.as_ref().unwrap() })
+        }
+
+        function::<T>
+    }
+}
+
+impl<T> ClosureToFunction<ExternIndexedPropertySetterCallbackV2> for T
+where
+    T: Fn(u32, Local<Value>, &PropertyCallbackInfo<()>) -> Intercepted,
+{
+    fn to_function(self) -> ExternIndexedPropertySetterCallbackV2 {
+        extern "C" fn function<T>(
+            index: u32,
+            value: Local<Value>,
+            pci: *const PropertyCallbackInfo<()>,
+        ) -> Intercepted
+        where
+            T: Fn(u32, Local<Value>, &PropertyCallbackInfo<()>) -> Intercepted,
+        {
+            T::get()(index, value, unsafe { pci.as_ref().unwrap() })
+        }
+
+        function::<T>
+    }
+}
+
+impl<T> ClosureToFunction<ExternIndexedPropertyQueryCallbackV2> for T
+where
+    T: Fn(u32, &PropertyCallbackInfo<Integer>) -> Intercepted,
+{
+    fn to_function(self) -> ExternIndexedPropertyQueryCallbackV2 {
+        extern "C" fn function<T>(
+            index: u32,
+            pci: *const PropertyCallbackInfo<Integer>,
+        ) -> Intercepted
+        where
+            T: Fn(u32, &PropertyCallbackInfo<Integer>) -> Intercepted,
+        {
+            T::get()(index, unsafe { pci.as_ref().unwrap() })
+        }
+
+        function::<T>
+    }
+}
+
+impl<T> ClosureToFunction<ExternIndexedPropertyDeleterCallbackV2> for T
+where
+    T: Fn(u32, &PropertyCallbackInfo<Boolean>) -> Intercepted,
+{
+    fn to_function(self) -> ExternIndexedPropertyDeleterCallbackV2 {
+        extern "C" fn function<T>(
+            index: u32,
+            pci: *const PropertyCallbackInfo<Boolean>,
+        ) -> Intercepted
+        where
+            T: Fn(u32, &PropertyCallbackInfo<Boolean>) -> Intercepted,
+        {
+            T::get()(index, unsafe { pci.as_ref().unwrap() })
+        }
+
+        function::<T>
+    }
+}
+
+impl<T> ClosureToFunction<ExternIndexedPropertyDefinerCallbackV2> for T
+where
+    T: Fn(u32, &PropertyDescriptor, &PropertyCallbackInfo<()>) -> Intercepted,
+{
+    fn to_function(self) -> ExternIndexedPropertyDefinerCallbackV2 {
+        extern "C" fn function<T>(
+            index: u32,
+            desc: *const PropertyDescriptor,
+            pci: *const PropertyCallbackInfo<()>,
+        ) -> Intercepted
+        where
+            T: Fn(u32, &PropertyDescriptor, &PropertyCallbackInfo<()>) -> Intercepted,
+        {
+            T::get()(index, unsafe { desc.as_ref().unwrap() }, unsafe {
+                pci.as_ref().unwrap()
+            })
+        }
+
+        function::<T>
+    }
+}

--- a/v8/src/property_callback_info.rs
+++ b/v8/src/property_callback_info.rs
@@ -1,0 +1,109 @@
+use std::{
+    marker::PhantomData,
+    mem::{transmute, MaybeUninit},
+};
+
+use crate::{
+    bindings,
+    isolate::Isolate,
+    local::Local,
+    object::Object,
+    return_value::ReturnValue,
+    value::{self, traits::Value},
+};
+
+extern "C" {
+    fn v8cxx_property_callback_info_get_isolate(
+        this: *const PropertyCallbackInfo<value::Value>,
+    ) -> *mut Isolate;
+    fn v8cxx_property_callback_info_data(
+        local_buf: *mut Local<value::Value>,
+        this: *const PropertyCallbackInfo<value::Value>,
+    );
+    fn v8cxx_property_callback_info_this(
+        local_buf: *mut Local<Object>,
+        this: *const PropertyCallbackInfo<value::Value>,
+    );
+    fn v8cxx_property_callback_info_holder(
+        local_buf: *mut Local<Object>,
+        this: *const PropertyCallbackInfo<value::Value>,
+    );
+    fn v8cxx_property_callback_info_get_return_value(
+        buf: *mut ReturnValue<value::Value>,
+        this: *const PropertyCallbackInfo<value::Value>,
+    );
+    fn v8cxx_property_callback_info_should_throw_on_error(
+        this: *const PropertyCallbackInfo<value::Value>,
+    ) -> bool;
+}
+
+#[repr(C)]
+pub struct PropertyCallbackInfo<T>(
+    [u8; bindings::v8cxx__sizeof_propertycallbackinfo],
+    PhantomData<T>,
+);
+
+impl<T> PropertyCallbackInfo<T> {
+    #[inline(always)]
+    pub fn cast<U: Value>(self) -> PropertyCallbackInfo<U> {
+        PropertyCallbackInfo(self.0, PhantomData)
+    }
+
+    #[inline(always)]
+    pub fn cast_ref<U: Value>(&self) -> &PropertyCallbackInfo<U> {
+        unsafe { transmute(self) }
+    }
+
+    #[inline(always)]
+    pub fn cast_mut<U: Value>(&mut self) -> &mut PropertyCallbackInfo<U> {
+        unsafe { transmute(self) }
+    }
+
+    #[inline(always)]
+    pub fn get_isolate(&self) -> Option<&mut Isolate> {
+        unsafe { v8cxx_property_callback_info_get_isolate(self.cast_ref()).as_mut() }
+    }
+
+    #[inline(always)]
+    pub fn data(&self) -> Local<value::Value> {
+        let mut local_value = Local::empty();
+
+        unsafe { v8cxx_property_callback_info_data(&mut local_value, self.cast_ref()) };
+
+        local_value
+    }
+
+    #[inline(always)]
+    pub fn this(&self) -> Local<Object> {
+        let mut local_object = Local::empty();
+
+        unsafe { v8cxx_property_callback_info_this(&mut local_object, self.cast_ref()) };
+
+        local_object
+    }
+
+    #[inline(always)]
+    pub fn holder(&self) -> Local<Object> {
+        let mut local_object = Local::empty();
+
+        unsafe { v8cxx_property_callback_info_holder(&mut local_object, self.cast_ref()) };
+
+        local_object
+    }
+
+    #[inline(always)]
+    pub fn get_return_value(&self) -> ReturnValue<value::Value> {
+        unsafe {
+            let mut return_value = MaybeUninit::zeroed();
+
+            v8cxx_property_callback_info_get_return_value(return_value.as_mut_ptr(), self.cast_ref());
+
+            return_value.assume_init()
+        }
+    }
+
+    #[inline(always)]
+    pub fn should_throw_on_error(&self) -> bool {
+        unsafe { v8cxx_property_callback_info_should_throw_on_error(self.cast_ref()) }
+    }
+}

--- a/v8/src/return_value.rs
+++ b/v8/src/return_value.rs
@@ -1,0 +1,130 @@
+use std::{mem::transmute, ptr::NonNull};
+
+use crate::{
+    isolate::Isolate,
+    local::Local,
+    value::{self, traits::Value},
+};
+
+extern "C" {
+    fn v8cxx__return_value_set(
+        this: *mut ReturnValue<value::Value>,
+        value: *const Local<value::Value>,
+    );
+    fn v8cxx__return_value_set_bool(this: *mut ReturnValue<value::Value>, value: bool);
+    fn v8cxx__return_value_set_f64(this: *mut ReturnValue<value::Value>, value: f64);
+    fn v8cxx__return_value_set_i16(this: *mut ReturnValue<value::Value>, value: i16);
+    fn v8cxx__return_value_set_i32(this: *mut ReturnValue<value::Value>, value: i32);
+    fn v8cxx__return_value_set_i64(this: *mut ReturnValue<value::Value>, value: i64);
+    fn v8cxx__return_value_set_u16(this: *mut ReturnValue<value::Value>, value: u16);
+    fn v8cxx__return_value_set_u32(this: *mut ReturnValue<value::Value>, value: u32);
+    fn v8cxx__return_value_set_u64(this: *mut ReturnValue<value::Value>, value: u64);
+    fn v8cxx__return_value_set_null(this: *mut ReturnValue<value::Value>);
+    fn v8cxx__return_value_set_undefined(this: *mut ReturnValue<value::Value>);
+    fn v8cxx__return_value_set_false(this: *mut ReturnValue<value::Value>);
+    fn v8cxx__return_value_set_empty_string(this: *mut ReturnValue<value::Value>);
+    fn v8cxx__return_value_get_isolate(this: *const ReturnValue<value::Value>) -> *mut Isolate;
+    fn v8cxx__return_value_get(
+        local_buf: *mut Local<value::Value>,
+        this: *const ReturnValue<value::Value>,
+    );
+}
+
+#[repr(C)]
+pub struct ReturnValue<T: Value>(NonNull<T>);
+
+impl<T: Value> ReturnValue<T> {
+    #[inline(always)]
+    pub fn cast<U: Value>(self) -> ReturnValue<U> {
+        ReturnValue(self.0.cast())
+    }
+
+    #[inline(always)]
+    pub fn cast_ref<U: Value>(&self) -> &ReturnValue<U> {
+        unsafe { transmute(self) }
+    }
+
+    #[inline(always)]
+    pub fn cast_mut<U: Value>(&mut self) -> &mut ReturnValue<U> {
+        unsafe { transmute(self) }
+    }
+
+    #[inline(always)]
+    pub fn set(&mut self, value: &Local<impl Value>) {
+        unsafe { v8cxx__return_value_set(self.cast_mut(), value.cast_ref()) };
+    }
+
+    #[inline(always)]
+    pub fn set_bool(&mut self, value: bool) {
+        unsafe { v8cxx__return_value_set_bool(self.cast_mut(), value) };
+    }
+
+    #[inline(always)]
+    pub fn set_f64(&mut self, value: f64) {
+        unsafe { v8cxx__return_value_set_f64(self.cast_mut(), value) };
+    }
+
+    #[inline(always)]
+    pub fn set_i16(&mut self, value: i16) {
+        unsafe { v8cxx__return_value_set_i16(self.cast_mut(), value) };
+    }
+
+    #[inline(always)]
+    pub fn set_i32(&mut self, value: i32) {
+        unsafe { v8cxx__return_value_set_i32(self.cast_mut(), value) };
+    }
+
+    #[inline(always)]
+    pub fn set_i64(&mut self, value: i64) {
+        unsafe { v8cxx__return_value_set_i64(self.cast_mut(), value) };
+    }
+
+    #[inline(always)]
+    pub fn set_u16(&mut self, value: u16) {
+        unsafe { v8cxx__return_value_set_u16(self.cast_mut(), value) };
+    }
+
+    #[inline(always)]
+    pub fn set_u32(&mut self, value: u32) {
+        unsafe { v8cxx__return_value_set_u32(self.cast_mut(), value) };
+    }
+
+    #[inline(always)]
+    pub fn set_u64(&mut self, value: u64) {
+        unsafe { v8cxx__return_value_set_u64(self.cast_mut(), value) };
+    }
+
+    #[inline(always)]
+    pub fn set_null(&mut self) {
+        unsafe { v8cxx__return_value_set_null(self.cast_mut()) };
+    }
+
+    #[inline(always)]
+    pub fn set_undefined(&mut self) {
+        unsafe { v8cxx__return_value_set_undefined(self.cast_mut()) };
+    }
+
+    #[inline(always)]
+    pub fn set_false(&mut self) {
+        unsafe { v8cxx__return_value_set_false(self.cast_mut()) };
+    }
+
+    #[inline(always)]
+    pub fn set_empty_string(&mut self) {
+        unsafe { v8cxx__return_value_set_empty_string(self.cast_mut()) };
+    }
+
+    #[inline(always)]
+    pub fn get_isolate(&self) -> Option<&mut Isolate> {
+        unsafe { v8cxx__return_value_get_isolate(self.cast_ref()).as_mut() }
+    }
+
+    #[inline(always)]
+    pub fn get(&self) -> Local<impl Value> {
+        let mut local_value = Local::empty();
+
+        unsafe { v8cxx__return_value_get(&mut local_value, self.cast_ref()) };
+
+        local_value
+    }
+}

--- a/v8/src/script_origin.rs
+++ b/v8/src/script_origin.rs
@@ -1,0 +1,149 @@
+use std::mem::MaybeUninit;
+
+use crate::{bindings, data::Data, local::Local, value::Value};
+
+extern "C" {
+    fn v8cxx_script_origin_new(
+        buf: *mut ScriptOrigin,
+        resource_name: *const Local<Value>,
+        resource_line_offset: i32,
+        resource_column_offset: i32,
+        resource_is_shared_cross_origin: bool,
+        script_id: i32,
+        source_map_url: *const Local<Value>,
+        resource_is_opaque: bool,
+        is_wasm: bool,
+        is_module: bool,
+        host_defined_options: *const Local<Data>,
+    );
+    fn v8cxx_script_origin_resource_name(local_buf: *mut Local<Value>, this: *const ScriptOrigin);
+    fn v8cxx_script_origin_line_offset(this: *const ScriptOrigin) -> i32;
+    fn v8cxx_script_origin_column_offset(this: *const ScriptOrigin) -> i32;
+    fn v8cxx_script_origin_script_id(this: *const ScriptOrigin) -> i32;
+    fn v8cxx_script_origin_source_map_url(local_buf: *mut Local<Value>, this: *const ScriptOrigin);
+    fn v8cxx_script_origin_get_host_defined_options(
+        local_buf: *mut Local<Data>,
+        this: *const ScriptOrigin,
+    );
+    fn v8cxx_script_origin_is_module(this: *const ScriptOrigin) -> bool;
+    fn v8cxx_script_origin_is_opaque(this: *const ScriptOrigin) -> bool;
+    fn v8cxx_script_origin_is_shared_cross_origin(this: *const ScriptOrigin) -> bool;
+    fn v8cxx_script_origin_is_wasm(this: *const ScriptOrigin) -> bool;
+}
+
+#[repr(C)]
+pub struct ScriptOrigin([u8; bindings::v8cxx__sizeof_scriptorigin]);
+
+impl ScriptOrigin {
+    #[inline(always)]
+    pub fn new(
+        resource_name: &Local<Value>,
+        resource_line_offset: i32,
+        resource_column_offset: i32,
+        resource_is_shared_cross_origin: bool,
+        script_id: i32,
+        source_map_url: &Local<Value>,
+        resource_is_opaque: bool,
+        is_wasm: bool,
+        is_module: bool,
+        host_defined_options: &Local<Data>,
+    ) -> Self {
+        unsafe {
+            let mut script_origin = MaybeUninit::zeroed();
+
+            v8cxx_script_origin_new(
+                script_origin.as_mut_ptr(),
+                resource_name,
+                resource_line_offset,
+                resource_column_offset,
+                resource_is_shared_cross_origin,
+                script_id,
+                source_map_url,
+                resource_is_opaque,
+                is_wasm,
+                is_module,
+                host_defined_options,
+            );
+
+            script_origin.assume_init()
+        }
+    }
+
+    #[inline(always)]
+    pub fn new_default(resource_name: &Local<Value>) -> Self {
+        Self::new(
+            resource_name,
+            0,
+            0,
+            false,
+            -1,
+            &Local::empty(),
+            false,
+            false,
+            false,
+            &Local::empty(),
+        )
+    }
+
+    #[inline(always)]
+    pub fn resource_name(&self) -> Local<Value> {
+        let mut local_value = Local::empty();
+
+        unsafe { v8cxx_script_origin_resource_name(&mut local_value, self) };
+
+        local_value
+    }
+
+    #[inline(always)]
+    pub fn line_offset(&self) -> i32 {
+        unsafe { v8cxx_script_origin_line_offset(self) }
+    }
+
+    #[inline(always)]
+    pub fn column_offset(&self) -> i32 {
+        unsafe { v8cxx_script_origin_column_offset(self) }
+    }
+
+    #[inline(always)]
+    pub fn script_id(&self) -> i32 {
+        unsafe { v8cxx_script_origin_script_id(self) }
+    }
+
+    #[inline(always)]
+    pub fn source_map_url(&self) -> Local<Value> {
+        let mut local_value = Local::empty();
+
+        unsafe { v8cxx_script_origin_source_map_url(&mut local_value, self) };
+
+        local_value
+    }
+
+    #[inline(always)]
+    pub fn get_host_defined_options(&self) -> Local<Data> {
+        let mut local_data = Local::empty();
+
+        unsafe { v8cxx_script_origin_get_host_defined_options(&mut local_data, self) };
+
+        local_data
+    }
+
+    #[inline(always)]
+    pub fn is_module(&self) -> bool {
+        unsafe { v8cxx_script_origin_is_module(self) }
+    }
+
+    #[inline(always)]
+    pub fn is_opaque(&self) -> bool {
+        unsafe { v8cxx_script_origin_is_opaque(self) }
+    }
+
+    #[inline(always)]
+    pub fn is_shared_cross_origin(&self) -> bool {
+        unsafe { v8cxx_script_origin_is_shared_cross_origin(self) }
+    }
+
+    #[inline(always)]
+    pub fn is_wasm(&self) -> bool {
+        unsafe { v8cxx_script_origin_is_wasm(self) }
+    }
+}

--- a/v8/src/signature.rs
+++ b/v8/src/signature.rs
@@ -1,0 +1,25 @@
+use crate::{data::traits::Data, isolate::Isolate, local::Local};
+
+extern "C" {
+    fn v8cxx__signature_new(
+        local_buf: *mut Local<Signature>,
+        isolate: *mut Isolate,
+        receiver: *const Local<FunctionTemplate>,
+    );
+}
+
+#[repr(C)]
+pub struct Signature([u8; 0]);
+
+impl Signature {
+    #[inline(always)]
+    pub fn new(isolate: &mut Isolate, receiver: &Local<FunctionTemplate>) -> Local<Self> {
+        let mut local_signature = Local::empty();
+
+        unsafe { v8cxx__signature_new(&mut local_signature, isolate, receiver) };
+
+        local_signature
+    }
+}
+
+impl Data for Signature {}

--- a/v8/src/signature.rs
+++ b/v8/src/signature.rs
@@ -1,4 +1,6 @@
-use crate::{data::traits::Data, isolate::Isolate, local::Local};
+use crate::{
+    data::traits::Data, function_template::FunctionTemplate, isolate::Isolate, local::Local,
+};
 
 extern "C" {
     fn v8cxx__signature_new(

--- a/v8/src/template.rs
+++ b/v8/src/template.rs
@@ -1,0 +1,73 @@
+use crate::{data::traits::Data, local::Local, object::PropertyAttribute};
+
+extern "C" {
+    fn v8cxx__template_set(
+        this: *mut Template,
+        name: *const Local<Name>,
+        value: *const Local<data::Data>,
+        attributes: PropertyAttribute,
+    );
+    fn v8cxx__template_set_private(
+        this: *mut Template,
+        name: *const Local<Name>,
+        value: *const Local<data::Data>,
+        attributes: PropertyAttribute,
+    );
+    fn v8cxx__template_set_with_isolate(
+        this: *mut Template,
+        isolate: *mut Isolate,
+        name: *const u8,
+        value: *const Local<data::Data>,
+        attributes: PropertyAttribute,
+    );
+}
+
+#[repr(C)]
+pub struct Template([u8; 0]);
+
+impl Data for Template {}
+
+pub mod traits {
+    use std::ffi::CStr;
+
+    use crate::{
+        data::{self, traits::Data},
+        local::Local,
+        name::Name,
+        object::PropertyAttribute,
+    };
+
+    use super::{v8cxx__template_set, v8cxx__template_set_with_isolate};
+
+    pub trait Template: Data {
+        fn set(
+            &mut self,
+            name: &Local<impl Name>,
+            value: &Local<impl data::Data>,
+            attributes: PropertyAttribute,
+        ) {
+            unsafe { v8cxx__template_set(self, name, value, attributes) };
+        }
+
+        fn set_private(
+            &mut self,
+            name: &Local<impl Name>,
+            value: &Local<impl data::Data>,
+            attributes: PropertyAttribute,
+        ) {
+            unsafe { v8cxx__template_set_private(self, name, value, attributes) };
+        }
+
+        fn set_with_isolate(
+            &mut self,
+            isolate: &mut Isolate,
+            name: CStr,
+            value: &Local<impl data::Data>,
+            attributes: PropertyAttribute,
+        ) {
+            unsafe {
+                v8cxx__template_set_with_isolate(self, isolate, name.as_ptr(), value, attributes)
+            };
+        }
+    }
+}

--- a/v8/src/template.rs
+++ b/v8/src/template.rs
@@ -1,4 +1,12 @@
-use crate::{data::traits::Data, local::Local, object::PropertyAttribute};
+use crate::{
+    data::{self, traits::Data},
+    function_template::FunctionTemplate,
+    isolate::Isolate,
+    local::Local,
+    name::Name,
+    object::PropertyAttribute,
+    private::Private,
+};
 
 extern "C" {
     fn v8cxx__template_set(
@@ -9,7 +17,7 @@ extern "C" {
     );
     fn v8cxx__template_set_private(
         this: *mut Template,
-        name: *const Local<Name>,
+        name: *const Local<Private>,
         value: *const Local<data::Data>,
         attributes: PropertyAttribute,
     );
@@ -20,53 +28,97 @@ extern "C" {
         value: *const Local<data::Data>,
         attributes: PropertyAttribute,
     );
+    fn v8cxx__template_set_accessor_property(
+        this: *mut Template,
+        name: *const Local<Name>,
+        getter: *const Local<FunctionTemplate>,
+        setter: *const Local<FunctionTemplate>,
+        attribute: PropertyAttribute,
+    );
 }
 
 #[repr(C)]
 pub struct Template([u8; 0]);
 
 impl Data for Template {}
+impl traits::Template for Template {}
 
 pub mod traits {
-    use std::ffi::CStr;
+    use std::ffi::CString;
 
     use crate::{
-        data::{self, traits::Data},
-        local::Local,
-        name::Name,
-        object::PropertyAttribute,
+        data::traits::Data, function_template::FunctionTemplate, isolate::Isolate, local::Local,
+        name::traits::Name, object::PropertyAttribute,
     };
 
-    use super::{v8cxx__template_set, v8cxx__template_set_with_isolate};
+    use super::*;
 
     pub trait Template: Data {
         fn set(
             &mut self,
             name: &Local<impl Name>,
-            value: &Local<impl data::Data>,
+            value: &Local<impl Data>,
             attributes: PropertyAttribute,
         ) {
-            unsafe { v8cxx__template_set(self, name, value, attributes) };
+            unsafe {
+                v8cxx__template_set(
+                    self as *mut _ as *mut _,
+                    name.cast_ref(),
+                    value.cast_ref(),
+                    attributes,
+                )
+            };
         }
 
         fn set_private(
             &mut self,
             name: &Local<impl Name>,
-            value: &Local<impl data::Data>,
+            value: &Local<impl Data>,
             attributes: PropertyAttribute,
         ) {
-            unsafe { v8cxx__template_set_private(self, name, value, attributes) };
+            unsafe {
+                v8cxx__template_set_private(
+                    self as *mut _ as *mut _,
+                    name.cast_ref(),
+                    value.cast_ref(),
+                    attributes,
+                )
+            };
         }
 
         fn set_with_isolate(
             &mut self,
             isolate: &mut Isolate,
-            name: CStr,
-            value: &Local<impl data::Data>,
+            name: CString,
+            value: &Local<impl Data>,
             attributes: PropertyAttribute,
         ) {
             unsafe {
-                v8cxx__template_set_with_isolate(self, isolate, name.as_ptr(), value, attributes)
+                v8cxx__template_set_with_isolate(
+                    self as *mut _ as *mut _,
+                    isolate,
+                    name.as_ptr() as *const u8,
+                    value.cast_ref(),
+                    attributes,
+                )
+            };
+        }
+
+        fn set_accessor_property(
+            &mut self,
+            name: &Local<impl Name>,
+            getter: &Local<FunctionTemplate>,
+            setter: &Local<FunctionTemplate>,
+            attribute: PropertyAttribute,
+        ) {
+            unsafe {
+                v8cxx__template_set_accessor_property(
+                    self as *mut _ as *mut _,
+                    name.cast_ref(),
+                    getter,
+                    setter,
+                    attribute,
+                )
             };
         }
     }


### PR DESCRIPTION
In this PR were added:
- `v8::Array`
- `v8::FunctionCallbackInfo<T>`
- `v8::FunctionTemplate`
- `v8::Function` 
- `v8::Integer`
- `v8::Number trait`
- `v8::ObjectTemplate` 
- `v8::PropertyCallbackInfo<T>`
- `v8::ReturnValue<T>`
- `v8::ScriptOrigin`
- `v8::Signature`
- `v8::Template`