### PR TITLE
feat(V8): added get_unbound_script method for v8::Script

### DIFF
--- a/v8/src/cpp/v8.cc
+++ b/v8/src/cpp/v8.cc
@@ -674,7 +674,6 @@ void v8cxx__script_run(v8::MaybeLocal<v8::Value>* maybe_local_buf,
   new (maybe_local_buf) v8::MaybeLocal<v8::Value>(script->Run(*context));
 }
 
-// TODO: add this to v8::script::Script (Rust)
 void v8cxx__script_get_unbound_script(v8::Local<v8::UnboundScript>* local_buf,
                                       v8::Script* script) {
   new (local_buf) v8::Local<v8::UnboundScript>(script->GetUnboundScript());

--- a/v8/src/script.rs
+++ b/v8/src/script.rs
@@ -3,6 +3,7 @@ use crate::{
     data::traits::Data,
     local::{Local, MaybeLocal},
     string::String,
+    unbound_script::UnboundScript,
     value::Value,
 };
 
@@ -12,13 +13,12 @@ extern "C" {
         context: *const Local<Context>,
         source: *const Local<String>,
     );
-
     fn v8cxx__script_run(
         maybe_local_buf: *mut MaybeLocal<Value>,
         script: *mut Script,
         context: *const Local<Context>,
     );
-
+    fn v8cxx__get_unbound_script(local_buf: *mut Local<UnboundScript>, this: *mut Script);
     fn v8cxx__script_get_resource_name(local_buf: *mut Local<Value>, script: *mut Script);
 }
 
@@ -44,6 +44,15 @@ impl Script {
         }
 
         maybe_local_value
+    }
+
+    #[inline(always)]
+    pub fn get_unbound_script(&mut self) -> Local<UnboundScript> {
+        let mut local_unbound_script = Local::empty();
+
+        unsafe { v8cxx__get_unbound_script(&mut local_unbound_script, self) };
+
+        local_unbound_script
     }
 
     #[inline(always)]


### PR DESCRIPTION
In this PR was added `get_unbound_script` method for `v8::Script`.