### PR TITLE
feat(V8): added v8::ScriptCompiler and v8::ScriptCompiler::Source structs, fixed C-style callbacks with return value

### DIFF
--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -1,4 +1,4 @@
-use v8::{object::traits::Object, value::traits::Value};
+use v8::{local::MaybeLocal, value::traits::Value};
 
 fn main() {
     let platform = v8::platform::Platform::new(
@@ -21,73 +21,96 @@ fn main() {
         let context = v8::context::Context::new(handle_scope, None);
         let context_scope = &mut v8::scope::ContextScope::new(context);
 
-        let mut test = v8::object::Object::new(handle_scope);
-
-        test.set(
-            &context_scope,
-            &v8::string::String::new(handle_scope, "test").to_local_checked(),
-            &v8::string::String::new(handle_scope, "test").to_local_checked(),
-            None,
-        );
-
-        println!(
-            "{{ test: {} }}",
-            test.get(
-                &context_scope,
-                &v8::string::String::new(handle_scope, "test").to_local_checked(),
-                None
-            )
-            .cast::<v8::string::String>()
-            .to_local_checked()
-            .as_str(handle_scope)
-        );
-
-        let synthetic_module_name =
-            v8::string::String::new(isolate, "test-module").to_local_checked();
-
-        let synthetic_module_exports =
-            vec![v8::string::String::new(isolate, "test").to_local_checked()];
-
-        let test_module = v8::module::Module::create_synthetic_module(
-            handle_scope,
-            &synthetic_module_name,
-            synthetic_module_exports,
-            |mut context, mut module| {
-                let isolate = context.get_isolate().unwrap();
-
-                let export_test = (
-                    v8::string::String::new(isolate, "test").to_local_checked(),
-                    v8::string::String::new(isolate, "value of test").to_local_checked(),
-                );
-
-                module.set_synthetic_module_export(
-                    isolate,
-                    export_test.0.cast_ref(),
-                    export_test.1.cast_ref(),
-                );
-
-                v8::local::MaybeLocal::empty()
-            },
-        );
-
-        println!(
-            "test_module.is_synthetic_module() = {}",
-            test_module.is_synthetic_module()
-        );
-
         let source = v8::string::String::new(
             handle_scope,
             r#"
-            import { test } from "test-module";
+            import { test } from "test-module" with { type: "attrval" };
 
-            test
+            test("hello, world!");
             "#,
         )
         .to_local_checked();
 
-        let mut script = v8::script::Script::compile(&context_scope, &source).to_local_checked();
+        let script_origin = v8::script_origin::ScriptOrigin::new_default(
+            v8::string::String::new(handle_scope, "main")
+                .to_local_checked()
+                .cast_ref(),
+            true,
+        );
 
-        let result = script.run(&context_scope).to_local_checked();
+        let source = &mut v8::script_compiler::Source::new(&source, &script_origin);
+        let mut main_module =
+            v8::script_compiler::ScriptCompiler::compile_module(handle_scope, source)
+                .to_local_checked();
+
+        main_module.instantiate_module(
+            context_scope,
+            |mut context, specifier, _import_attributes, _referrer| {
+                let isolate = context.get_isolate().unwrap();
+                let specifier_name = specifier.as_str(isolate);
+
+                match specifier_name {
+                    "test-module" => v8::local::MaybeLocal::from_local({
+                        let synthetic_module_name =
+                            v8::string::String::new(isolate, "test-module").to_local_checked();
+
+                        let synthetic_module_exports =
+                            vec![v8::string::String::new(isolate, "test").to_local_checked()];
+
+                        _import_attributes
+                            .iter(&isolate.get_current_context())
+                            .for_each(|attribute| {
+                                let attribute_string = attribute.cast::<v8::string::String>();
+
+                                if attribute_string.is_string() {
+                                    println!("attribute = {}", attribute_string.as_str(isolate));
+                                }
+                            });
+
+                        v8::module::Module::create_synthetic_module(
+                            isolate,
+                            &synthetic_module_name,
+                            synthetic_module_exports,
+                            |mut context, mut module| {
+                                let isolate = context.get_isolate().unwrap();
+
+                                let export_test = (
+                                    v8::string::String::new(isolate, "test").to_local_checked(),
+                                    v8::function::Function::new_default(
+                                        &isolate.get_current_context(),
+                                        |pci| {
+                                            let isolate = pci.get_isolate().unwrap();
+
+                                            println!(
+                                                "printed value = {}",
+                                                pci.at(0)
+                                                    .to_string(&isolate.get_current_context())
+                                                    .to_local_checked()
+                                                    .as_str(isolate)
+                                            );
+                                        },
+                                    )
+                                    .to_local_checked(),
+                                );
+
+                                module.set_synthetic_module_export(
+                                    isolate,
+                                    export_test.0.cast_ref(),
+                                    export_test.1.cast_ref(),
+                                );
+
+                                MaybeLocal::from_local(
+                                    v8::boolean::Boolean::new(isolate, true).cast(),
+                                )
+                            },
+                        )
+                    }),
+                    _ => v8::local::MaybeLocal::empty(),
+                }
+            },
+        );
+
+        let result = main_module.evaluate(context_scope).to_local_checked();
 
         println!(
             "result = {}",

--- a/v8/src/cpp/v8.cc
+++ b/v8/src/cpp/v8.cc
@@ -567,9 +567,8 @@ void v8cxx__string_internalize_string(v8::Local<v8::String>* local_buf,
 }
 
 const char* v8cxx__string_view(const v8::String* string, v8::Isolate* isolate) {
-  auto local_string =
-      string->ToString(isolate->GetCurrentContext()).ToLocalChecked();
-  return *v8::String::Utf8Value(isolate, local_string);
+  return *v8::String::Utf8Value(
+      isolate, string->ToString(isolate->GetCurrentContext()).ToLocalChecked());
 }
 }
 
@@ -714,9 +713,7 @@ bool v8cxx__object_set(v8::Object* object,
                        const v8::MaybeLocal<v8::Object>* receiver) {
   auto result = false;
 
-  object->Set(*context, *key, *value, *receiver).FromMaybe(&result);
-
-  return result;
+  return object->Set(*context, *key, *value, *receiver).FromMaybe(&result);
 }
 
 bool v8cxx__object_set_indexed(v8::Object* object,
@@ -725,9 +722,7 @@ bool v8cxx__object_set_indexed(v8::Object* object,
                                const v8::Local<v8::Value>* value) {
   auto result = false;
 
-  object->Set(*context, index, *value).FromMaybe(&result);
-
-  return result;
+  return object->Set(*context, index, *value).FromMaybe(&result);
 }
 
 bool v8cxx__object_create_data_property(v8::Object* object,
@@ -736,9 +731,7 @@ bool v8cxx__object_create_data_property(v8::Object* object,
                                         const v8::Local<v8::Value>* value) {
   auto result = false;
 
-  object->CreateDataProperty(*context, *key, *value).FromMaybe(&result);
-
-  return result;
+  return object->CreateDataProperty(*context, *key, *value).FromMaybe(&result);
 }
 
 bool v8cxx__object_create_data_property_indexed(
@@ -748,9 +741,7 @@ bool v8cxx__object_create_data_property_indexed(
     const v8::Local<v8::Value>* value) {
   auto result = false;
 
-  object->CreateDataProperty(*context, index, *value).FromMaybe(&result);
-
-  return result;
+  return object->CreateDataProperty(*context, index, *value).FromMaybe(&result);
 }
 
 bool v8cxx__object_define_own_property(v8::Object* object,
@@ -760,10 +751,8 @@ bool v8cxx__object_define_own_property(v8::Object* object,
                                        v8::PropertyAttribute attributes) {
   auto result = false;
 
-  object->DefineOwnProperty(*context, *key, *value, attributes)
+  return object->DefineOwnProperty(*context, *key, *value, attributes)
       .FromMaybe(&result);
-
-  return result;
 }
 
 // TODO: v8cxx__object_define_property
@@ -827,15 +816,10 @@ int v8cxx__module_get_identity_hash(const v8::Module* module) {
 bool v8cxx__module_instantiate_module(
     v8::Module* module,
     const v8::Local<v8::Context>* context,
-    v8::Module::ResolveModuleCallback module_callback
-    // v8::Module::ResolveSourceCallback source_callback
-) {
+    v8::Module::ResolveModuleCallback module_callback) {
   auto result = false;
 
-  module->InstantiateModule(*context, module_callback, nullptr)
-      .FromMaybe(&result);
-
-  return result;
+  return module->InstantiateModule(*context, module_callback).FromMaybe(&result);
 }
 
 void v8cxx__module_evaluate(v8::MaybeLocal<v8::Value>* maybe_local_buf,
@@ -898,10 +882,8 @@ bool v8cxx__module_set_synthetic_module_export(
     const v8::Local<v8::Value>* export_value) {
   auto result = false;
 
-  module->SetSyntheticModuleExport(isolate, *export_name, *export_value)
+  return module->SetSyntheticModuleExport(isolate, *export_name, *export_value)
       .FromMaybe(&result);
-
-  return result;
 }
 
 // TODO: v8::Module::GetStalledTopLevelAwaitMessages
@@ -912,10 +894,18 @@ extern "C" {
 void v8cxx__local_empty(v8::Local<v8::Data>* local_buf) {
   new (local_buf) v8::Local<v8::Data>();
 }
+
+bool v8cxx__local_is_empty(const v8::Local<v8::Data>* local) {
+  return local->IsEmpty();
+}
 }
 
 // v8::MaybeLocal
 extern "C" {
+void v8cxx__maybe_local_empty(v8::MaybeLocal<v8::Data>* maybe_local_buf) {
+  new (maybe_local_buf) v8::MaybeLocal<v8::Data>(v8::MaybeLocal<v8::Data>());
+}
+
 bool v8cxx__maybe_local_is_empty(const v8::MaybeLocal<v8::Data>* maybe_local) {
   return maybe_local->IsEmpty();
 }
@@ -1634,5 +1624,57 @@ int v8cxx__unbound_script_get_line_number(v8::UnboundScript* us, int code_pos) {
 int v8cxx__unbound_script_get_column_number(v8::UnboundScript* us,
                                             int code_pos) {
   return us->GetColumnNumber(code_pos);
+}
+}
+
+// v8::ScriptCompiler
+extern "C" {
+void v8cxx__script_compiler_compile_unbound_script(
+    v8::MaybeLocal<v8::UnboundScript>* maybe_local_buf,
+    v8::Isolate* isolate,
+    v8::ScriptCompiler::Source* source) {
+  new (maybe_local_buf) v8::MaybeLocal<v8::UnboundScript>(
+      v8::ScriptCompiler::CompileUnboundScript(isolate, source));
+}
+
+void v8cxx__script_compiler_compile(v8::MaybeLocal<v8::Script>* maybe_local_buf,
+                                    const v8::Local<v8::Context>* context,
+                                    v8::ScriptCompiler::Source* source) {
+  new (maybe_local_buf)
+      v8::MaybeLocal<v8::Script>(v8::ScriptCompiler::Compile(*context, source));
+}
+
+void v8cxx__script_compiler_compile_module(
+    v8::MaybeLocal<v8::Module>* maybe_local_buf,
+    v8::Isolate* isolate,
+    v8::ScriptCompiler::Source* source) {
+  new (maybe_local_buf) v8::MaybeLocal<v8::Module>(
+      v8::ScriptCompiler::CompileModule(isolate, source));
+}
+
+void v8cxx__script_compiler_compile_function(
+    v8::MaybeLocal<v8::Function>* maybe_local_buf,
+    const v8::Local<v8::Context>* context,
+    v8::ScriptCompiler::Source* source,
+    size_t arguments_count,
+    v8::Local<v8::String>* arguments,
+    size_t context_extension_count,
+    v8::Local<v8::Object>* context_extensions) {
+  new (maybe_local_buf)
+      v8::MaybeLocal<v8::Function>(v8::ScriptCompiler::CompileFunction(
+          *context, source, arguments_count, arguments, context_extension_count,
+          context_extensions));
+}
+
+// TODO: implement other methods if needed
+}
+
+// v8::ScriptCompiler::Source
+extern "C" {
+void v8cxx__script_compiler__source_new(
+    v8::ScriptCompiler::Source* buf,
+    const v8::Local<v8::String>* source_string,
+    const v8::ScriptOrigin* origin) {
+  new (buf) v8::ScriptCompiler::Source(*source_string, *origin);
 }
 }

--- a/v8/src/cpp/v8.hpp
+++ b/v8/src/cpp/v8.hpp
@@ -11,3 +11,5 @@ static size_t v8cxx__sizeof_functioncallbackinfo =
     sizeof(v8::FunctionCallbackInfo<void>);
 static size_t v8cxx__sizeof_propertycallbackinfo =
     sizeof(v8::PropertyCallbackInfo<void>);
+static size_t v8cxx__sizeof_scriptcompiler__source =
+    sizeof(v8::ScriptCompiler::Source);

--- a/v8/src/function.rs
+++ b/v8/src/function.rs
@@ -93,6 +93,21 @@ impl Function {
     }
 
     #[inline(always)]
+    pub fn new_default<F>(context: &Local<Context>, callback: F) -> MaybeLocal<Function>
+    where
+        F: Fn(&FunctionCallbackInfo<value::Value>),
+    {
+        Self::new(
+            context,
+            callback,
+            Local::<value::Value>::empty().cast_ref(),
+            0,
+            ConstructorBehavior::Allow,
+            SideEffectType::HasSideEffect,
+        )
+    }
+
+    #[inline(always)]
     pub fn new_instance(
         &self,
         context: &Local<Context>,

--- a/v8/src/lib.rs
+++ b/v8/src/lib.rs
@@ -34,6 +34,7 @@ pub mod property_callback_info;
 pub mod return_value;
 pub mod scope;
 pub mod script;
+pub mod script_compiler;
 pub mod script_origin;
 pub mod signature;
 pub mod string;

--- a/v8/src/script_compiler.rs
+++ b/v8/src/script_compiler.rs
@@ -1,0 +1,131 @@
+use std::mem::MaybeUninit;
+
+use crate::{
+    bindings,
+    context::Context,
+    function::Function,
+    isolate::Isolate,
+    local::{Local, MaybeLocal},
+    module::Module,
+    object::Object,
+    script::Script,
+    script_origin::ScriptOrigin,
+    string::String,
+    unbound_script::UnboundScript,
+};
+
+extern "C" {
+    fn v8cxx__script_compiler_compile_unbound_script(
+        maybe_local_buf: *mut MaybeLocal<UnboundScript>,
+        isolate: *mut Isolate,
+        source: *mut Source,
+    );
+    fn v8cxx__script_compiler_compile(
+        maybe_local_buf: *mut MaybeLocal<Script>,
+        context: *const Local<Context>,
+        source: *mut Source,
+    );
+    fn v8cxx__script_compiler_compile_module(
+        maybe_local_buf: *mut MaybeLocal<Module>,
+        isolate: *mut Isolate,
+        source: *mut Source,
+    );
+    fn v8cxx__script_compiler_compile_function(
+        maybe_local_buf: *mut MaybeLocal<Function>,
+        context: *const Local<Context>,
+        source: *mut Source,
+        arguments_count: usize,
+        arguments: *mut Local<String>,
+        context_extension_count: usize,
+        context_extensions: *mut Local<Object>,
+    );
+}
+
+#[repr(C)]
+pub struct ScriptCompiler([u8; 0]);
+
+impl ScriptCompiler {
+    #[inline(always)]
+    pub fn compile_unbound_script(
+        isolate: &mut Isolate,
+        source: &mut Source,
+    ) -> MaybeLocal<UnboundScript> {
+        let mut maybe_local_unbound_script = MaybeLocal::empty();
+
+        unsafe {
+            v8cxx__script_compiler_compile_unbound_script(
+                &mut maybe_local_unbound_script,
+                isolate,
+                source,
+            )
+        };
+
+        maybe_local_unbound_script
+    }
+
+    #[inline(always)]
+    pub fn compile(context: &Local<Context>, source: &mut Source) -> MaybeLocal<Script> {
+        let mut maybe_local_script = MaybeLocal::empty();
+
+        unsafe { v8cxx__script_compiler_compile(&mut maybe_local_script, context, source) };
+
+        maybe_local_script
+    }
+
+    #[inline(always)]
+    pub fn compile_module(isolate: &mut Isolate, source: &mut Source) -> MaybeLocal<Module> {
+        let mut maybe_local_module = MaybeLocal::empty();
+
+        unsafe { v8cxx__script_compiler_compile_module(&mut maybe_local_module, isolate, source) };
+
+        maybe_local_module
+    }
+
+    #[inline(always)]
+    pub fn compile_function(
+        context: &Local<Context>,
+        source: &mut Source,
+        arguments: &mut Vec<Local<String>>,
+        context_extensions: &mut Vec<Local<Object>>,
+    ) -> MaybeLocal<Function> {
+        let mut maybe_local_function = MaybeLocal::empty();
+
+        unsafe {
+            v8cxx__script_compiler_compile_function(
+                &mut maybe_local_function,
+                context,
+                source,
+                arguments.len(),
+                arguments.as_mut_ptr(),
+                context_extensions.len(),
+                context_extensions.as_mut_ptr(),
+            )
+        };
+
+        maybe_local_function
+    }
+}
+
+extern "C" {
+    fn v8cxx__script_compiler__source_new(
+        buf: *mut Source,
+        source_string: *const Local<String>,
+        origin: *const ScriptOrigin,
+    );
+}
+
+#[repr(C)]
+pub struct Source([u8; bindings::v8cxx__sizeof_scriptcompiler__source]);
+
+impl Source {
+    #[inline(always)]
+    pub fn new(source_string: &Local<String>, origin: &ScriptOrigin) -> Self {
+        unsafe {
+            let mut source = MaybeUninit::uninit();
+
+            v8cxx__script_compiler__source_new(source.as_mut_ptr(), source_string, origin);
+
+            source.assume_init()
+        }
+    }
+}

--- a/v8/src/script_origin.rs
+++ b/v8/src/script_origin.rs
@@ -3,7 +3,7 @@ use std::mem::MaybeUninit;
 use crate::{bindings, data::Data, local::Local, value::Value};
 
 extern "C" {
-    fn v8cxx_script_origin_new(
+    fn v8cxx__script_origin_new(
         buf: *mut ScriptOrigin,
         resource_name: *const Local<Value>,
         resource_line_offset: i32,
@@ -16,19 +16,19 @@ extern "C" {
         is_module: bool,
         host_defined_options: *const Local<Data>,
     );
-    fn v8cxx_script_origin_resource_name(local_buf: *mut Local<Value>, this: *const ScriptOrigin);
-    fn v8cxx_script_origin_line_offset(this: *const ScriptOrigin) -> i32;
-    fn v8cxx_script_origin_column_offset(this: *const ScriptOrigin) -> i32;
-    fn v8cxx_script_origin_script_id(this: *const ScriptOrigin) -> i32;
-    fn v8cxx_script_origin_source_map_url(local_buf: *mut Local<Value>, this: *const ScriptOrigin);
-    fn v8cxx_script_origin_get_host_defined_options(
+    fn v8cxx__script_origin_resource_name(local_buf: *mut Local<Value>, this: *const ScriptOrigin);
+    fn v8cxx__script_origin_line_offset(this: *const ScriptOrigin) -> i32;
+    fn v8cxx__script_origin_column_offset(this: *const ScriptOrigin) -> i32;
+    fn v8cxx__script_origin_script_id(this: *const ScriptOrigin) -> i32;
+    fn v8cxx__script_origin_source_map_url(local_buf: *mut Local<Value>, this: *const ScriptOrigin);
+    fn v8cxx__script_origin_get_host_defined_options(
         local_buf: *mut Local<Data>,
         this: *const ScriptOrigin,
     );
-    fn v8cxx_script_origin_is_module(this: *const ScriptOrigin) -> bool;
-    fn v8cxx_script_origin_is_opaque(this: *const ScriptOrigin) -> bool;
-    fn v8cxx_script_origin_is_shared_cross_origin(this: *const ScriptOrigin) -> bool;
-    fn v8cxx_script_origin_is_wasm(this: *const ScriptOrigin) -> bool;
+    fn v8cxx__script_origin_is_module(this: *const ScriptOrigin) -> bool;
+    fn v8cxx__script_origin_is_opaque(this: *const ScriptOrigin) -> bool;
+    fn v8cxx__script_origin_is_shared_cross_origin(this: *const ScriptOrigin) -> bool;
+    fn v8cxx__script_origin_is_wasm(this: *const ScriptOrigin) -> bool;
 }
 
 #[repr(C)]
@@ -51,7 +51,7 @@ impl ScriptOrigin {
         unsafe {
             let mut script_origin = MaybeUninit::zeroed();
 
-            v8cxx_script_origin_new(
+            v8cxx__script_origin_new(
                 script_origin.as_mut_ptr(),
                 resource_name,
                 resource_line_offset,
@@ -70,7 +70,7 @@ impl ScriptOrigin {
     }
 
     #[inline(always)]
-    pub fn new_default(resource_name: &Local<Value>) -> Self {
+    pub fn new_default(resource_name: &Local<Value>, is_module: bool) -> Self {
         Self::new(
             resource_name,
             0,
@@ -80,7 +80,7 @@ impl ScriptOrigin {
             &Local::empty(),
             false,
             false,
-            false,
+            is_module,
             &Local::empty(),
         )
     }
@@ -89,31 +89,31 @@ impl ScriptOrigin {
     pub fn resource_name(&self) -> Local<Value> {
         let mut local_value = Local::empty();
 
-        unsafe { v8cxx_script_origin_resource_name(&mut local_value, self) };
+        unsafe { v8cxx__script_origin_resource_name(&mut local_value, self) };
 
         local_value
     }
 
     #[inline(always)]
     pub fn line_offset(&self) -> i32 {
-        unsafe { v8cxx_script_origin_line_offset(self) }
+        unsafe { v8cxx__script_origin_line_offset(self) }
     }
 
     #[inline(always)]
     pub fn column_offset(&self) -> i32 {
-        unsafe { v8cxx_script_origin_column_offset(self) }
+        unsafe { v8cxx__script_origin_column_offset(self) }
     }
 
     #[inline(always)]
     pub fn script_id(&self) -> i32 {
-        unsafe { v8cxx_script_origin_script_id(self) }
+        unsafe { v8cxx__script_origin_script_id(self) }
     }
 
     #[inline(always)]
     pub fn source_map_url(&self) -> Local<Value> {
         let mut local_value = Local::empty();
 
-        unsafe { v8cxx_script_origin_source_map_url(&mut local_value, self) };
+        unsafe { v8cxx__script_origin_source_map_url(&mut local_value, self) };
 
         local_value
     }
@@ -122,28 +122,28 @@ impl ScriptOrigin {
     pub fn get_host_defined_options(&self) -> Local<Data> {
         let mut local_data = Local::empty();
 
-        unsafe { v8cxx_script_origin_get_host_defined_options(&mut local_data, self) };
+        unsafe { v8cxx__script_origin_get_host_defined_options(&mut local_data, self) };
 
         local_data
     }
 
     #[inline(always)]
     pub fn is_module(&self) -> bool {
-        unsafe { v8cxx_script_origin_is_module(self) }
+        unsafe { v8cxx__script_origin_is_module(self) }
     }
 
     #[inline(always)]
     pub fn is_opaque(&self) -> bool {
-        unsafe { v8cxx_script_origin_is_opaque(self) }
+        unsafe { v8cxx__script_origin_is_opaque(self) }
     }
 
     #[inline(always)]
     pub fn is_shared_cross_origin(&self) -> bool {
-        unsafe { v8cxx_script_origin_is_shared_cross_origin(self) }
+        unsafe { v8cxx__script_origin_is_shared_cross_origin(self) }
     }
 
     #[inline(always)]
     pub fn is_wasm(&self) -> bool {
-        unsafe { v8cxx_script_origin_is_wasm(self) }
+        unsafe { v8cxx__script_origin_is_wasm(self) }
     }
 }


### PR DESCRIPTION
In this PR were added `v8::ScriptCompiler` and `v8::ScriptCompiler::Source` structs from V8.

Additionally, fixed seg. fault with STATUS_ACCESS_VIOLATION for callbacks which return values.